### PR TITLE
hotfix/#48: 비로그인 사용자 게시글 목록 볼 수 있게 수정

### DIFF
--- a/src/main/java/com/example/nexus/app/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/nexus/app/global/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.example.nexus.app.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -40,6 +41,7 @@ public class SecurityConfig {
                                 "/swagger-resources/**", "/webjars/**",
                                 "/auth/login", "/auth/reissue"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/v1/users/posts/list").permitAll()
                         .requestMatchers("/api/v1/users/profile").hasAnyRole("GUEST", "USER")
                         .requestMatchers("/auth/me", "/v1/users/**").authenticated()
                         .anyRequest().authenticated() // 이제부터, 운영환경과 동일한 시큐리티 필터체인 사용.

--- a/src/main/java/com/example/nexus/app/post/controller/PostController.java
+++ b/src/main/java/com/example/nexus/app/post/controller/PostController.java
@@ -103,9 +103,8 @@ public class PostController {
             @RequestParam(required = false) String keyword,
             @Parameter(description = "정렬 기준 (latest, popular, deadline, viewCount)")
             @RequestParam(defaultValue = "latest") String sortBy,
-            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(size = 20) Pageable pageable) {
-        Page<PostSummaryResponse> posts = postService.findPosts(mainCategory, platformCategory, genreCategory, keyword, sortBy, userDetails.getUserId(), pageable);
+        Page<PostSummaryResponse> posts = postService.findPosts(mainCategory, platformCategory, genreCategory, keyword, sortBy, pageable);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(posts));
     }

--- a/src/main/java/com/example/nexus/app/post/service/PostService.java
+++ b/src/main/java/com/example/nexus/app/post/service/PostService.java
@@ -125,7 +125,7 @@ public class PostService {
     }
 
     public Page<PostSummaryResponse> findPosts(String mainCategory, String platformCategory,
-                                               String genreCategory, String keyword, String sortBy, Long userId, Pageable pageable) {
+                                               String genreCategory, String keyword, String sortBy, Pageable pageable) {
         PostSearchCondition condition = PostSearchCondition.builder()
                 .mainCategory(parseMainCategory(mainCategory))
                 .platformCategory(parsePlatformCategory(platformCategory))


### PR DESCRIPTION
# 구현 기능
- /v1/users/posts/list 비로그인 사용자도 접근 허용
- 목록 조회 컨트롤러에서 @AuthenticationPrincipal 제거