### PR TITLE
Feat/#54 작성 가능한 리뷰, 작성한 리뷰 구분 API 구현

### DIFF
--- a/src/main/java/com/example/nexus/app/review/dto/ReviewStatusResponse.java
+++ b/src/main/java/com/example/nexus/app/review/dto/ReviewStatusResponse.java
@@ -1,0 +1,28 @@
+package com.example.nexus.app.review.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+/**
+ * 리뷰 작성 상태 응답 DTO
+ */
+@Getter
+@Builder
+public class ReviewStatusResponse {
+
+    private Long postId;
+    private Boolean canWriteReview;
+    private Boolean hasWrittenReview;
+    private ReviewInfo existingReview;
+
+    @Getter
+    @Builder
+    public static class ReviewInfo {
+        private Long reviewId;
+        private Integer rating;
+        private String content;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+    }
+}

--- a/src/main/java/com/example/nexus/app/review/dto/WritableReviewResponse.java
+++ b/src/main/java/com/example/nexus/app/review/dto/WritableReviewResponse.java
@@ -1,0 +1,29 @@
+package com.example.nexus.app.review.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+/**
+ * 작성 가능한 리뷰 응답 DTO
+ */
+@Getter
+@Builder
+public class WritableReviewResponse {
+
+    private Long postId;
+    private String postTitle;
+    private String postThumbnail;
+    private String category;
+    private LocalDateTime approvedAt;
+    private Boolean canWriteReview;
+
+    @Getter
+    @Builder
+    public static class PostInfo {
+        private Long id;
+        private String title;
+        private String thumbnail;
+        private String category;
+    }
+}

--- a/src/main/java/com/example/nexus/app/review/dto/WrittenReviewResponse.java
+++ b/src/main/java/com/example/nexus/app/review/dto/WrittenReviewResponse.java
@@ -1,0 +1,33 @@
+package com.example.nexus.app.review.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+/**
+ * 작성한 리뷰 응답 DTO
+ */
+@Getter
+@Builder
+public class WrittenReviewResponse {
+
+    private Long reviewId;
+    private Long postId;
+    private String postTitle;
+    private String postThumbnail;
+    private String category;
+    private Integer rating;
+    private String content;
+    private LocalDateTime reviewCreatedAt;
+    private LocalDateTime reviewUpdatedAt;
+    private Boolean canEdit;
+
+    @Getter
+    @Builder
+    public static class PostInfo {
+        private Long id;
+        private String title;
+        private String thumbnail;
+        private String category;
+    }
+}

--- a/src/main/java/com/example/nexus/app/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/nexus/app/review/repository/ReviewRepository.java
@@ -4,9 +4,12 @@ import com.example.nexus.app.review.domain.Review;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * - 게시글별 리뷰 목록 조회 등 커스텀 메서드 추가 가능
@@ -20,4 +23,20 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Long countByPostId(Long postId);
 
     Long countByPostIdAndCreatedAtBefore(Long postId, LocalDateTime dateTime);
+
+    // 사용자가 작성한 리뷰 목록 조회
+    @Query("SELECT r FROM Review r " +
+            "JOIN FETCH r.createdBy " +
+            "WHERE r.createdBy.id = :userId " +
+            "ORDER BY r.createdAt DESC")
+    Page<Review> findByCreatedByOrderByCreatedAtDesc(@Param("userId") Long userId, Pageable pageable);
+
+    // 사용자가 특정 게시글에 작성한 리뷰 조회
+    @Query("SELECT r FROM Review r " +
+            "WHERE r.createdBy.id = :userId AND r.postId = :postId")
+    Optional<Review> findByCreatedByAndPostId(@Param("userId") Long userId, @Param("postId") Long postId);
+
+    // 사용자가 작성한 리뷰가 있는 게시글 ID 목록 조회
+    @Query("SELECT DISTINCT r.postId FROM Review r WHERE r.createdBy.id = :userId")
+    List<Long> findPostIdsByCreatedBy(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/nexus/app/review/service/ReviewService.java
+++ b/src/main/java/com/example/nexus/app/review/service/ReviewService.java
@@ -3,17 +3,26 @@ package com.example.nexus.app.review.service;
 import com.example.nexus.app.review.domain.Review;
 import com.example.nexus.app.review.dto.ReviewCreateRequest;
 import com.example.nexus.app.review.dto.ReviewUpdateRequest;
+import com.example.nexus.app.review.dto.WritableReviewResponse;
+import com.example.nexus.app.review.dto.WrittenReviewResponse;
+import com.example.nexus.app.review.dto.ReviewStatusResponse;
 import com.example.nexus.app.review.repository.ReviewRepository;
+import com.example.nexus.app.post.domain.ParticipationStatus;
+import com.example.nexus.app.post.repository.ParticipationRepository;
+import com.example.nexus.app.post.repository.PostRepository;
 import com.example.nexus.app.user.domain.User;
 import com.example.nexus.app.user.repository.UserRepository;
 import com.example.nexus.app.global.code.status.ErrorStatus;
 import com.example.nexus.app.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * ReviewService
@@ -24,6 +33,8 @@ import java.util.Optional;
 public class ReviewService {
 
     private final ReviewRepository reviewRepository;
+    private final ParticipationRepository participationRepository;
+    private final PostRepository postRepository;
     private final UserRepository userRepository;
 
     @Transactional
@@ -78,5 +89,89 @@ public class ReviewService {
         }
 
         reviewRepository.deleteById(reviewId);
+    }
+
+    // 작성 가능한 리뷰 목록 조회
+    @Transactional(readOnly = true)
+    public Page<WritableReviewResponse> getWritableReviews(Long userId, Pageable pageable) {
+        // 사용자가 참여 승인된 게시글 목록 조회
+        Page<com.example.nexus.app.post.domain.Participation> participations = 
+            participationRepository.findByUserIdAndStatusWithPost(userId, ParticipationStatus.APPROVED, pageable);
+
+        // 사용자가 이미 리뷰를 작성한 게시글 ID 목록 조회
+        List<Long> reviewedPostIds = reviewRepository.findPostIdsByCreatedBy(userId);
+
+        return participations.map(participation -> {
+            Long postId = participation.getPost().getId();
+            boolean canWriteReview = !reviewedPostIds.contains(postId);
+
+            return WritableReviewResponse.builder()
+                    .postId(postId)
+                    .postTitle(participation.getPost().getTitle())
+                    .postThumbnail(participation.getPost().getThumbnailUrl())
+                    .category(participation.getPost().getMainCategory().iterator().next().name())
+                    .approvedAt(participation.getApprovedAt())
+                    .canWriteReview(canWriteReview)
+                    .build();
+        });
+    }
+
+    // 작성한 리뷰 목록 조회
+    @Transactional(readOnly = true)
+    public Page<WrittenReviewResponse> getWrittenReviews(Long userId, Pageable pageable) {
+        Page<Review> reviews = reviewRepository.findByCreatedByOrderByCreatedAtDesc(userId, pageable);
+
+        return reviews.map(review -> {
+            // Post 정보 조회
+            com.example.nexus.app.post.domain.Post post = postRepository.findById(review.getPostId())
+                    .orElse(null);
+
+            return WrittenReviewResponse.builder()
+                    .reviewId(review.getId())
+                    .postId(review.getPostId())
+                    .postTitle(post != null ? post.getTitle() : "삭제된 게시글")
+                    .postThumbnail(post != null ? post.getThumbnailUrl() : null)
+                    .category(post != null && !post.getMainCategory().isEmpty() ? 
+                            post.getMainCategory().iterator().next().name() : "카테고리 없음")
+                    .rating(review.getRating())
+                    .content(review.getContent())
+                    .reviewCreatedAt(review.getCreatedAt())
+                    .reviewUpdatedAt(review.getUpdatedAt())
+                    .canEdit(true) // TODO: 수정 가능 여부 로직 추가
+                    .build();
+        });
+    }
+
+    // 리뷰 작성 상태 확인
+    @Transactional(readOnly = true)
+    public ReviewStatusResponse getReviewStatus(Long userId, Long postId) {
+        // 사용자가 해당 게시글에 참여했는지 확인
+        boolean hasParticipated = participationRepository.existsByUserIdAndPostIdAndStatus(
+                userId, postId, ParticipationStatus.APPROVED);
+
+        // 사용자가 해당 게시글에 리뷰를 작성했는지 확인
+        Optional<Review> existingReview = reviewRepository.findByCreatedByAndPostId(userId, postId);
+
+        boolean canWriteReview = hasParticipated && existingReview.isEmpty();
+        boolean hasWrittenReview = existingReview.isPresent();
+
+        ReviewStatusResponse.ReviewInfo reviewInfo = null;
+        if (existingReview.isPresent()) {
+            Review review = existingReview.get();
+            reviewInfo = ReviewStatusResponse.ReviewInfo.builder()
+                    .reviewId(review.getId())
+                    .rating(review.getRating())
+                    .content(review.getContent())
+                    .createdAt(review.getCreatedAt())
+                    .updatedAt(review.getUpdatedAt())
+                    .build();
+        }
+
+        return ReviewStatusResponse.builder()
+                .postId(postId)
+                .canWriteReview(canWriteReview)
+                .hasWrittenReview(hasWrittenReview)
+                .existingReview(reviewInfo)
+                .build();
     }
 }


### PR DESCRIPTION
- [ ] 작성 가능한 리뷰 목록 API
  - 엔드포인트: `GET /v1/users/reviews/writable`
  - 기능: 사용자가 참여했지만 아직 리뷰를 작성하지 않은 게시글 목록
  - 페이지네이션 지원 (기본 10개)
  - 응답: 게시글 정보, 참여 승인 일시

- [ ] 리뷰 작성 상태 확인 API
  - 엔드포인트: `GET /v1/users/reviews/status/{postId}`
  - 기능: 특정 게시글에 대한 리뷰 작성 가능 여부 확인
  - 응답: 작성 가능 여부, 기존 리뷰 정보 (있다면)