### PR TITLE
Fix/#60 : LazyLoadingException 수정

### DIFF
--- a/src/main/java/com/example/nexus/app/review/controller/ReviewController.java
+++ b/src/main/java/com/example/nexus/app/review/controller/ReviewController.java
@@ -1,7 +1,5 @@
 package com.example.nexus.app.review.controller;
 
-import com.example.nexus.app.global.oauth.domain.CustomUserDetails;
-import com.example.nexus.app.review.domain.Review;
 import com.example.nexus.app.review.dto.ReviewCreateRequest;
 import com.example.nexus.app.review.dto.ReviewResponse;
 import com.example.nexus.app.review.dto.ReviewUpdateRequest;
@@ -12,17 +10,18 @@ import com.example.nexus.app.review.service.ReviewService;
 import com.example.nexus.app.global.code.dto.ApiResponse;
 import com.example.nexus.app.global.code.status.ErrorStatus;
 import com.example.nexus.app.global.exception.GeneralException;
+import com.example.nexus.app.global.oauth.domain.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
 import java.util.List;
-import java.util.stream.Collectors;
-import io.swagger.v3.oas.annotations.Operation;
 
 /**
  * ReviewController
@@ -45,9 +44,9 @@ public class ReviewController {
         if (userDetails == null) {
             throw new GeneralException(ErrorStatus.UNAUTHORIZED);
         }
-        Review review = reviewService.createReview(request, userDetails.getUserId());
+        ReviewResponse review = reviewService.createReview(request, userDetails.getUserId());
         return ResponseEntity.status(201)
-                .body(ApiResponse.onSuccess(toResponse(review)));
+                .body(ApiResponse.onSuccess(review));
     }
 
     @Operation(summary = "리뷰 하나만 조회", description = "리뷰 ID로 단일 리뷰를 조회합니다.")
@@ -55,9 +54,9 @@ public class ReviewController {
     public ResponseEntity<ApiResponse<ReviewResponse>> getReview(
             @PathVariable Long id
     ) {
-        Review review = reviewService.getReview(id)
+        ReviewResponse review = reviewService.getReview(id)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.RESOURCE_NOT_FOUND));
-        return ResponseEntity.ok(ApiResponse.onSuccess(toResponse(review)));
+        return ResponseEntity.ok(ApiResponse.onSuccess(review));
     }
 
     @Operation(summary = "게시글 별 리뷰 목록 조회", description = "게시글 ID로 해당 게시글의 모든 리뷰를 조회합니다.")
@@ -65,10 +64,7 @@ public class ReviewController {
     public ResponseEntity<ApiResponse<List<ReviewResponse>>> getReviewsByPostId(
             @PathVariable Long postId
     ) {
-        List<ReviewResponse> responses = reviewService.getReviewsByPostId(postId)
-                .stream()
-                .map(this::toResponse)
-                .collect(Collectors.toList());
+        List<ReviewResponse> responses = reviewService.getReviewsByPostId(postId);
         return ResponseEntity.ok(ApiResponse.onSuccess(responses));
     }
 
@@ -82,8 +78,8 @@ public class ReviewController {
         if (userDetails == null) {
             throw new GeneralException(ErrorStatus.UNAUTHORIZED);
         }
-        Review updated = reviewService.updateReview(id, request, userDetails.getUserId());
-        return ResponseEntity.ok(ApiResponse.onSuccess(toResponse(updated)));
+        ReviewResponse updated = reviewService.updateReview(id, request, userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(updated));
     }
 
     @Operation(summary = "리뷰 삭제", description = "리뷰 작성자만 리뷰를 삭제할 수 있습니다.")
@@ -136,22 +132,6 @@ public class ReviewController {
         }
         ReviewStatusResponse response = reviewService.getReviewStatus(userDetails.getUserId(), postId);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
-    }
-
-    private ReviewResponse toResponse(Review review) {
-        return ReviewResponse.builder()
-                .id(review.getId())
-                .postId(review.getPostId())
-                .rating(review.getRating())
-                .content(review.getContent())
-                .createdAt(review.getCreatedAt())
-                .updatedAt(review.getUpdatedAt())
-                .writer(ReviewResponse.WriterInfo.builder()
-                        .id(review.getCreatedBy().getId())
-                        .nickname(review.getCreatedBy().getNickname())
-                        .profileUrl(review.getCreatedBy().getProfileUrl())
-                        .build())
-                .build();
     }
 
 }

--- a/src/main/java/com/example/nexus/app/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/nexus/app/review/repository/ReviewRepository.java
@@ -15,8 +15,13 @@ import java.util.Optional;
  * - 게시글별 리뷰 목록 조회 등 커스텀 메서드 추가 가능
  */
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-    // postId의 리뷰 목록 조회
-    List<Review> findByPostId(Long postId);
+    // 단일 리뷰 조회 (작성자 정보 포함)
+    @Query("SELECT r FROM Review r JOIN FETCH r.createdBy WHERE r.id = :id")
+    Optional<Review> findByIdWithCreatedBy(@Param("id") Long id);
+    
+    // postId의 리뷰 목록 조회 (작성자 정보 포함)
+    @Query("SELECT r FROM Review r JOIN FETCH r.createdBy WHERE r.postId = :postId")
+    List<Review> findByPostId(@Param("postId") Long postId);
 
     Page<Review> findByPostIdOrderByCreatedAtDesc(Long postId, Pageable pageable);
 


### PR DESCRIPTION
###  ReviewRepository 수정

* `findByIdWithCreatedBy()` 메서드 추가: 페치 조인을 사용하여 Review와 User 엔티티를 한 번에 조회
* `findByPostId()` 메서드 수정: 페치 조인을 사용하여 작성자 정보를 함께 로드

### ReviewService 수정

* 모든 메서드가 ReviewResponse DTO를 반환하도록 변경
* `toReviewResponse()` 메서드 추가: 엔티티를 DTO로 변환하는 로직을 서비스 계층으로 이동
* 트랜잭션 내에서 모든 필요한 데이터를 로드하여 DTO로 변환

### ReviewController 수정

* 엔티티 대신 DTO를 직접 사용하도록 변경
* `toResponse()` 메서드 제거: 더 이상 컨트롤러에서 엔티티 변환을 하지 않음
