### PR TITLE
Feat/#62 정보 관리 api 구현

### DIFF
--- a/src/main/java/com/example/nexus/app/account/controller/AccountManagementController.java
+++ b/src/main/java/com/example/nexus/app/account/controller/AccountManagementController.java
@@ -1,0 +1,90 @@
+package com.example.nexus.app.account.controller;
+
+import com.example.nexus.app.account.dto.AccountManagementResponse;
+import com.example.nexus.app.account.dto.BasicInfoUpdateRequest;
+import com.example.nexus.app.account.dto.CustomInfoUpdateRequest;
+import com.example.nexus.app.account.dto.PersonalInfoUpdateRequest;
+import com.example.nexus.app.account.dto.AccountWithdrawalRequest;
+import com.example.nexus.app.account.dto.KakaoAccountInfoResponse;
+import com.example.nexus.app.account.service.AccountManagementService;
+import com.example.nexus.app.global.code.dto.ApiResponse;
+import com.example.nexus.app.global.oauth.domain.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "계정관리", description = "계정관리 API")
+@RestController
+@RequestMapping("/api/v1/account")
+@RequiredArgsConstructor
+public class AccountManagementController {
+
+    private final AccountManagementService accountManagementService;
+
+    @Operation(summary = "계정관리 정보 조회", description = "현재 로그인한 사용자의 계정관리 정보를 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<AccountManagementResponse>> getAccountManagementInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        AccountManagementResponse response = accountManagementService.getAccountManagementInfo(userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "카카오 계정 정보 조회", description = "현재 로그인한 사용자의 카카오 계정 연결 정보를 조회합니다.")
+    @GetMapping("/kakao")
+    public ResponseEntity<ApiResponse<KakaoAccountInfoResponse>> getKakaoAccountInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        KakaoAccountInfoResponse response = accountManagementService.getKakaoAccountInfo(userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "기본정보 수정", description = "활동명과 프로필 이미지를 수정합니다.")
+    @PutMapping(value = "/basic-info", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<AccountManagementResponse>> updateBasicInfo(
+            @RequestPart("basicInfo") @Valid BasicInfoUpdateRequest request,
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        AccountManagementResponse response = accountManagementService.updateBasicInfo(userDetails.getUserId(), request, profileImage);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "개인정보 수정", description = "전화번호를 수정합니다.")
+    @PutMapping("/personal-info")
+    public ResponseEntity<ApiResponse<AccountManagementResponse>> updatePersonalInfo(
+            @Valid @RequestBody PersonalInfoUpdateRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        AccountManagementResponse response = accountManagementService.updatePersonalInfo(userDetails.getUserId(), request);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "맞춤정보 수정", description = "직업, 출생년도, 성별, 관심사, 선호 장르를 수정합니다.")
+    @PutMapping("/custom-info")
+    public ResponseEntity<ApiResponse<AccountManagementResponse>> updateCustomInfo(
+            @Valid @RequestBody CustomInfoUpdateRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        AccountManagementResponse response = accountManagementService.updateCustomInfo(userDetails.getUserId(), request);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "로그아웃", description = "현재 사용자를 로그아웃 처리합니다.")
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        accountManagementService.logout(userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+    }
+
+    @Operation(summary = "계정 탈퇴", description = "현재 사용자의 계정을 탈퇴 처리합니다.")
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<ApiResponse<Void>> withdrawAccount(
+            @Valid @RequestBody AccountWithdrawalRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        accountManagementService.withdrawAccount(userDetails.getUserId(), request.confirmation());
+        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+    }
+}

--- a/src/main/java/com/example/nexus/app/account/controller/AccountManagementController.java
+++ b/src/main/java/com/example/nexus/app/account/controller/AccountManagementController.java
@@ -84,7 +84,7 @@ public class AccountManagementController {
     public ResponseEntity<ApiResponse<Void>> withdrawAccount(
             @Valid @RequestBody AccountWithdrawalRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        accountManagementService.withdrawAccount(userDetails.getUserId(), request.confirmation());
+        accountManagementService.withdrawAccount(userDetails.getUserId(), request.confirmation(), request.kakaoAccessToken());
         return ResponseEntity.ok(ApiResponse.onSuccess(null));
     }
 }

--- a/src/main/java/com/example/nexus/app/account/domain/AccountInfo.java
+++ b/src/main/java/com/example/nexus/app/account/domain/AccountInfo.java
@@ -1,0 +1,78 @@
+package com.example.nexus.app.account.domain;
+
+import com.example.nexus.app.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "account_info")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class AccountInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(name = "phone_number")
+    private String phoneNumber;
+
+    @Column(name = "birth_year")
+    private String birthYear;
+
+    @Column(name = "gender")
+    private String gender;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "account_preferred_genres", joinColumns = @JoinColumn(name = "account_info_id"))
+    @Column(name = "preferred_genre")
+    private List<String> preferredGenres = new ArrayList<>();
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public AccountInfo(User user, String phoneNumber, String birthYear, String gender, List<String> preferredGenres) {
+        this.user = user;
+        this.phoneNumber = phoneNumber;
+        this.birthYear = birthYear;
+        this.gender = gender;
+        this.preferredGenres = preferredGenres != null ? preferredGenres : new ArrayList<>();
+    }
+
+    public void updatePhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public void updateBirthYear(String birthYear) {
+        this.birthYear = birthYear;
+    }
+
+    public void updateGender(String gender) {
+        this.gender = gender;
+    }
+
+    public void updatePreferredGenres(List<String> preferredGenres) {
+        this.preferredGenres = preferredGenres != null ? preferredGenres : new ArrayList<>();
+    }
+}

--- a/src/main/java/com/example/nexus/app/account/dto/AccountManagementResponse.java
+++ b/src/main/java/com/example/nexus/app/account/dto/AccountManagementResponse.java
@@ -1,0 +1,58 @@
+package com.example.nexus.app.account.dto;
+
+import com.example.nexus.app.account.domain.AccountInfo;
+import com.example.nexus.app.mypage.domain.UserProfile;
+import com.example.nexus.app.user.domain.User;
+import com.example.nexus.app.user.domain.SocialType;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record AccountManagementResponse(
+    // 기본정보
+    String nickname,
+    String profileUrl,
+    
+    // 개인정보
+    String email,
+    String phoneNumber,
+    String connectedAccount,
+    
+    // 맞춤정보
+    String job,
+    String birthYear,
+    String gender,
+    List<String> interests,
+    List<String> preferredGenres
+) {
+    public static AccountManagementResponse from(User user, UserProfile userProfile, AccountInfo accountInfo) {
+        return AccountManagementResponse.builder()
+            .nickname(user.getNickname())
+            .profileUrl(user.getProfileUrl())
+            .email(user.getEmail())
+            .phoneNumber(accountInfo != null ? accountInfo.getPhoneNumber() : null)
+            .connectedAccount(formatConnectedAccount(user.getSocialType(), user.getEmail()))
+            .job(userProfile != null ? userProfile.getJob() : null)
+            .birthYear(accountInfo != null ? accountInfo.getBirthYear() : null)
+            .gender(accountInfo != null ? accountInfo.getGender() : null)
+            .interests(userProfile != null ? userProfile.getInterests() : List.of())
+            .preferredGenres(accountInfo != null ? accountInfo.getPreferredGenres() : List.of())
+            .build();
+    }
+
+    private static String formatConnectedAccount(SocialType socialType, String email) {
+        if (socialType == null) return null;
+        
+        switch (socialType) {
+            case KAKAO:
+                return "카카오 (" + email + ")";
+            case GOOGLE:
+                return "구글 (" + email + ")";
+            case APPLE:
+                return "애플 (" + email + ")";
+            default:
+                return socialType.name() + " (" + email + ")";
+        }
+    }
+}

--- a/src/main/java/com/example/nexus/app/account/dto/AccountWithdrawalRequest.java
+++ b/src/main/java/com/example/nexus/app/account/dto/AccountWithdrawalRequest.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 @Builder
 public record AccountWithdrawalRequest(
     @NotBlank(message = "탈퇴 확인 문구를 입력해주세요.")
-    String confirmation
+    String confirmation,
+    
+    String kakaoAccessToken
 ) {
 }

--- a/src/main/java/com/example/nexus/app/account/dto/AccountWithdrawalRequest.java
+++ b/src/main/java/com/example/nexus/app/account/dto/AccountWithdrawalRequest.java
@@ -1,0 +1,11 @@
+package com.example.nexus.app.account.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record AccountWithdrawalRequest(
+    @NotBlank(message = "탈퇴 확인 문구를 입력해주세요.")
+    String confirmation
+) {
+}

--- a/src/main/java/com/example/nexus/app/account/dto/BasicInfoUpdateRequest.java
+++ b/src/main/java/com/example/nexus/app/account/dto/BasicInfoUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.example.nexus.app.account.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+@Builder
+public record BasicInfoUpdateRequest(
+    @NotBlank(message = "활동명은 필수입니다.")
+    @Size(min = 1, max = 20, message = "활동명은 1자 이상 20자 이하여야 합니다.")
+    String nickname
+) {
+}

--- a/src/main/java/com/example/nexus/app/account/dto/CustomInfoUpdateRequest.java
+++ b/src/main/java/com/example/nexus/app/account/dto/CustomInfoUpdateRequest.java
@@ -1,0 +1,26 @@
+package com.example.nexus.app.account.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CustomInfoUpdateRequest(
+    @NotBlank(message = "직업은 필수입니다.")
+    String job,
+    
+    @Pattern(regexp = "^[0-9]{4}년$", message = "출생년도는 'YYYY년' 형식이어야 합니다.")
+    String birthYear,
+    
+    @NotBlank(message = "성별은 필수입니다.")
+    @Size(max = 10, message = "성별은 10자 이하여야 합니다.")
+    String gender,
+    
+    List<String> interests,
+    
+    List<String> preferredGenres
+) {
+}

--- a/src/main/java/com/example/nexus/app/account/dto/KakaoAccountInfoResponse.java
+++ b/src/main/java/com/example/nexus/app/account/dto/KakaoAccountInfoResponse.java
@@ -1,0 +1,39 @@
+package com.example.nexus.app.account.dto;
+
+import com.example.nexus.app.user.domain.SocialType;
+import com.example.nexus.app.user.domain.User;
+import lombok.Builder;
+
+@Builder
+public record KakaoAccountInfoResponse(
+    String connectedAccount,
+    String email,
+    String nickname,
+    String profileUrl,
+    boolean isKakaoAccount
+) {
+    public static KakaoAccountInfoResponse from(User user) {
+        return KakaoAccountInfoResponse.builder()
+            .connectedAccount(formatConnectedAccount(user.getSocialType(), user.getEmail()))
+            .email(user.getEmail())
+            .nickname(user.getNickname())
+            .profileUrl(user.getProfileUrl())
+            .isKakaoAccount(user.getSocialType() == SocialType.KAKAO)
+            .build();
+    }
+
+    private static String formatConnectedAccount(SocialType socialType, String email) {
+        if (socialType == null) return null;
+        
+        switch (socialType) {
+            case KAKAO:
+                return "카카오 (" + email + ")";
+            case GOOGLE:
+                return "구글 (" + email + ")";
+            case APPLE:
+                return "애플 (" + email + ")";
+            default:
+                return socialType.name() + " (" + email + ")";
+        }
+    }
+}

--- a/src/main/java/com/example/nexus/app/account/dto/PersonalInfoUpdateRequest.java
+++ b/src/main/java/com/example/nexus/app/account/dto/PersonalInfoUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.example.nexus.app.account.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+
+@Builder
+public record PersonalInfoUpdateRequest(
+    @Pattern(regexp = "^01[0-9]-[0-9]{4}-[0-9]{4}$", message = "올바른 전화번호 형식이 아닙니다.")
+    String phoneNumber
+) {
+}

--- a/src/main/java/com/example/nexus/app/account/repository/AccountInfoRepository.java
+++ b/src/main/java/com/example/nexus/app/account/repository/AccountInfoRepository.java
@@ -1,0 +1,13 @@
+package com.example.nexus.app.account.repository;
+
+import com.example.nexus.app.account.domain.AccountInfo;
+import com.example.nexus.app.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AccountInfoRepository extends JpaRepository<AccountInfo, Long> {
+    Optional<AccountInfo> findByUser(User user);
+}

--- a/src/main/java/com/example/nexus/app/account/service/AccountManagementService.java
+++ b/src/main/java/com/example/nexus/app/account/service/AccountManagementService.java
@@ -1,0 +1,210 @@
+package com.example.nexus.app.account.service;
+
+import com.example.nexus.app.account.domain.AccountInfo;
+import com.example.nexus.app.account.dto.AccountManagementResponse;
+import com.example.nexus.app.account.dto.BasicInfoUpdateRequest;
+import com.example.nexus.app.account.dto.CustomInfoUpdateRequest;
+import com.example.nexus.app.account.dto.PersonalInfoUpdateRequest;
+import com.example.nexus.app.account.dto.KakaoAccountInfoResponse;
+import com.example.nexus.app.account.repository.AccountInfoRepository;
+import com.example.nexus.app.global.code.status.ErrorStatus;
+import com.example.nexus.app.global.exception.GeneralException;
+import com.example.nexus.app.global.s3.S3UploadService;
+import com.example.nexus.app.mypage.domain.UserProfile;
+import com.example.nexus.app.mypage.repository.UserProfileRepository;
+import com.example.nexus.app.user.domain.User;
+import com.example.nexus.app.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class AccountManagementService {
+
+    private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final AccountInfoRepository accountInfoRepository;
+    private final S3UploadService s3UploadService;
+
+    /**
+     * 계정관리 정보 조회
+     */
+    public AccountManagementResponse getAccountManagementInfo(Long userId) {
+        User user = getUser(userId);
+        UserProfile userProfile = userProfileRepository.findByUser(user).orElse(null);
+        AccountInfo accountInfo = accountInfoRepository.findByUser(user).orElse(null);
+        
+        return AccountManagementResponse.from(user, userProfile, accountInfo);
+    }
+
+    /**
+     * 카카오 계정 정보 조회
+     */
+    public KakaoAccountInfoResponse getKakaoAccountInfo(Long userId) {
+        User user = getUser(userId);
+        return KakaoAccountInfoResponse.from(user);
+    }
+
+    /**
+     * 기본정보 수정 (활동명, 프로필 이미지)
+     */
+    @Transactional
+    public AccountManagementResponse updateBasicInfo(Long userId, BasicInfoUpdateRequest request, MultipartFile profileImage) {
+        User user = getUser(userId);
+        
+        // 활동명 수정
+        if (request.nickname() != null && !request.nickname().trim().isEmpty()) {
+            user.updateNickname(request.nickname());
+        }
+        
+        // 프로필 이미지 수정
+        if (profileImage != null && !profileImage.isEmpty()) {
+            validateImageFile(profileImage);
+            
+            // 기존 이미지 삭제
+            if (user.getProfileUrl() != null && !isDefaultProfileImage(user.getProfileUrl())) {
+                try {
+                    s3UploadService.deleteFile(user.getProfileUrl());
+                } catch (Exception e) {
+                    log.warn("기존 프로필 이미지 삭제 실패: {}", e.getMessage());
+                }
+            }
+            
+            // 새 이미지 업로드
+            String imageUrl = s3UploadService.uploadFile(profileImage);
+            user.updateProfileImage(imageUrl);
+        }
+        
+        UserProfile userProfile = userProfileRepository.findByUser(user).orElse(null);
+        AccountInfo accountInfo = accountInfoRepository.findByUser(user).orElse(null);
+        
+        return AccountManagementResponse.from(user, userProfile, accountInfo);
+    }
+
+    /**
+     * 개인정보 수정 (전화번호)
+     * 카카오 계정의 경우 이메일은 카카오에서 관리하므로 수정 불가
+     */
+    @Transactional
+    public AccountManagementResponse updatePersonalInfo(Long userId, PersonalInfoUpdateRequest request) {
+        User user = getUser(userId);
+        AccountInfo accountInfo = getOrCreateAccountInfo(user);
+        
+        if (request.phoneNumber() != null) {
+            accountInfo.updatePhoneNumber(request.phoneNumber());
+        }
+        
+        UserProfile userProfile = userProfileRepository.findByUser(user).orElse(null);
+        
+        return AccountManagementResponse.from(user, userProfile, accountInfo);
+    }
+
+    /**
+     * 맞춤정보 수정
+     */
+    @Transactional
+    public AccountManagementResponse updateCustomInfo(Long userId, CustomInfoUpdateRequest request) {
+        User user = getUser(userId);
+        UserProfile userProfile = getOrCreateUserProfile(user);
+        AccountInfo accountInfo = getOrCreateAccountInfo(user);
+        
+        // UserProfile 업데이트
+        userProfile.update(request.job(), request.interests());
+        
+        // AccountInfo 업데이트
+        accountInfo.updateBirthYear(request.birthYear());
+        accountInfo.updateGender(request.gender());
+        accountInfo.updatePreferredGenres(request.preferredGenres());
+        
+        return AccountManagementResponse.from(user, userProfile, accountInfo);
+    }
+
+    /**
+     * 로그아웃
+     */
+    @Transactional
+    public void logout(Long userId) {
+        User user = getUser(userId);
+        // 리프레시 토큰 삭제
+        user.updateRefreshToken(null);
+    }
+
+    /**
+     * 계정 탈퇴
+     * 카카오 계정의 경우 카카오 연동 해제도 고려해야 함
+     */
+    @Transactional
+    public void withdrawAccount(Long userId, String confirmation) {
+        if (!"계정 탈퇴".equals(confirmation)) {
+            throw new GeneralException(ErrorStatus.BAD_REQUEST);
+        }
+        
+        User user = getUser(userId);
+        
+        // 계정 상태를 탈퇴로 변경
+        user.updateRefreshToken(null);
+        // TODO: User 엔티티에 withdrawAccount 메서드 추가 필요
+        // TODO: 카카오 연동 해제 API 호출 필요 (카카오 개발자 콘솔에서 설정)
+        
+        // 관련 데이터 삭제
+        userProfileRepository.findByUser(user).ifPresent(userProfileRepository::delete);
+        accountInfoRepository.findByUser(user).ifPresent(accountInfoRepository::delete);
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+    }
+
+    private UserProfile getOrCreateUserProfile(User user) {
+        return userProfileRepository.findByUser(user)
+                .orElseGet(() -> {
+                    UserProfile newProfile = UserProfile.builder()
+                            .user(user)
+                            .job("")
+                            .interests(new ArrayList<>())
+                            .build();
+                    return userProfileRepository.save(newProfile);
+                });
+    }
+
+    private AccountInfo getOrCreateAccountInfo(User user) {
+        return accountInfoRepository.findByUser(user)
+                .orElseGet(() -> {
+                    AccountInfo newAccountInfo = AccountInfo.builder()
+                            .user(user)
+                            .phoneNumber("")
+                            .birthYear("")
+                            .gender("")
+                            .preferredGenres(new ArrayList<>())
+                            .build();
+                    return accountInfoRepository.save(newAccountInfo);
+                });
+    }
+
+    private void validateImageFile(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new GeneralException(ErrorStatus.FILE_IS_EMPTY);
+        }
+        
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new GeneralException(ErrorStatus.INVALID_IMAGE_FORMAT);
+        }
+        
+        if (file.getSize() > 5 * 1024 * 1024) { // 5MB
+            throw new GeneralException(ErrorStatus.IMAGE_SIZE_EXCEEDED);
+        }
+    }
+
+    private boolean isDefaultProfileImage(String profileUrl) {
+        return profileUrl != null && profileUrl.contains("default");
+    }
+}

--- a/src/main/java/com/example/nexus/app/account/service/KakaoUnlinkService.java
+++ b/src/main/java/com/example/nexus/app/account/service/KakaoUnlinkService.java
@@ -1,0 +1,70 @@
+package com.example.nexus.app.account.service;
+
+import com.example.nexus.app.global.code.status.ErrorStatus;
+import com.example.nexus.app.global.exception.GeneralException;
+import com.example.nexus.app.user.domain.SocialType;
+import com.example.nexus.app.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoUnlinkService {
+
+    private final RestTemplate restTemplate;
+
+    private static final String KAKAO_UNLINK_URL = "https://kapi.kakao.com/v1/user/unlink";
+
+    /**
+     * 사용자 토큰으로 카카오 연동 해제
+     * @param user 카카오 연동 해제할 사용자
+     * @param accessToken 사용자가 제공한 카카오 액세스 토큰
+     */
+    public void unlinkKakaoAccount(User user, String accessToken) {
+        if (user.getSocialType() != SocialType.KAKAO) {
+            log.warn("카카오 계정이 아닌 사용자에 대한 연동 해제 시도: userId={}, socialType={}", 
+                    user.getId(), user.getSocialType());
+            return;
+        }
+
+        if (accessToken == null || accessToken.trim().isEmpty()) {
+            log.warn("카카오 액세스 토큰이 제공되지 않음: userId={}", user.getId());
+            return;
+        }
+
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "Bearer " + accessToken);
+            headers.set("Content-Type", "application/x-www-form-urlencoded");
+
+            HttpEntity<String> request = new HttpEntity<>(headers);
+
+            ResponseEntity<String> response = restTemplate.exchange(
+                    KAKAO_UNLINK_URL,
+                    HttpMethod.POST,
+                    request,
+                    String.class
+            );
+
+            if (response.getStatusCode().is2xxSuccessful()) {
+                log.info("카카오 연동 해제 성공: userId={}, oauthId={}", user.getId(), user.getOauthId());
+            } else {
+                log.error("카카오 연동 해제 실패: userId={}, statusCode={}", user.getId(), response.getStatusCode());
+                // 연동 해제 실패해도 계정 탈퇴는 진행 (토큰이 만료되었을 수 있음)
+                log.warn("카카오 연동 해제 실패했지만 계정 탈퇴는 계속 진행합니다.");
+            }
+
+        } catch (Exception e) {
+            log.error("카카오 연동 해제 중 오류 발생: userId={}, error={}", user.getId(), e.getMessage());
+            // 연동 해제 실패해도 계정 탈퇴는 진행
+            log.warn("카카오 연동 해제 중 오류가 발생했지만 계정 탈퇴는 계속 진행합니다.");
+        }
+    }
+}

--- a/src/main/java/com/example/nexus/app/global/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/nexus/app/global/code/status/ErrorStatus.java
@@ -75,6 +75,7 @@ public enum ErrorStatus implements BaseErrorCode {
     ALREADY_COMPLETED(HttpStatus.CONFLICT, "PARTICIPANT4096", "이미 완료 처리된 참여자입니다."),
     NOT_COMPLETED_YET(HttpStatus.CONFLICT, "PARTICIPANT4097", "아직 완료되지 않은 참여자입니다."),
     ALREADY_PAID(HttpStatus.CONFLICT, "PARTICIPANT4098", "이미 리워드가 지급된 참여자입니다."),
+    USER_ALREADY_WITHDRAWN(HttpStatus.CONFLICT, "USER4099", "이미 탈퇴된 계정입니다."),
 
     // 415 UNSUPPORTED_MEDIA_TYPE, 422 UNPROCESSABLE_ENTITY
     UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "COMMON415", "지원하지 않는 미디어 타입입니다."),

--- a/src/main/java/com/example/nexus/app/global/config/AsyncConfig.java
+++ b/src/main/java/com/example/nexus/app/global/config/AsyncConfig.java
@@ -3,22 +3,14 @@ package com.example.nexus.app.global.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
-
-import java.util.concurrent.Executor;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 @EnableAsync
 public class AsyncConfig {
 
-    @Bean(name = "taskExecutor")
-    public Executor taskExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(2);
-        executor.setMaxPoolSize(5);
-        executor.setQueueCapacity(100);
-        executor.setThreadNamePrefix("Async-");
-        executor.initialize();
-        return executor;
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/src/main/java/com/example/nexus/app/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/nexus/app/global/security/SecurityConfig.java
@@ -5,14 +5,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -30,23 +33,22 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .csrf(csrf -> csrf.disable())
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .csrf(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**",
-                                "/swagger-resources/**", "/webjars/**",
-                                "/auth/login", "/auth/reissue"
-                        ).permitAll()
-                        .requestMatchers(HttpMethod.GET, "/v1/users/posts/list").permitAll()
-                        .requestMatchers("/api/v1/users/profile").hasAnyRole("GUEST", "USER")
-                        .requestMatchers("/auth/me", "/v1/users/**").authenticated()
-                        .anyRequest().authenticated() // 이제부터, 운영환경과 동일한 시큐리티 필터체인 사용.
+                        .requestMatchers("/auth/**", "/api/v1/auth/**").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/v1/categories/**").permitAll()
+                        .requestMatchers("/api/v1/posts/**").permitAll()
+                        .requestMatchers("/api/v1/ranking/**").permitAll()
+                        .requestMatchers("/api/v1/users/profile").permitAll()
+                        .anyRequest().authenticated()
                 )
-                .addFilterBefore(jwtAuthenticationProcessingFilter(), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationProcessingFilter(), UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+                );
 
         return http.build();
     }

--- a/src/main/java/com/example/nexus/app/user/domain/StatusType.java
+++ b/src/main/java/com/example/nexus/app/user/domain/StatusType.java
@@ -3,5 +3,6 @@ package com.example.nexus.app.user.domain;
 public enum StatusType {
     UNVERIFIED,
     ACTIVE,
-    BANNED
+    BANNED,
+    WITHDRAWN
 }

--- a/src/main/java/com/example/nexus/app/user/domain/User.java
+++ b/src/main/java/com/example/nexus/app/user/domain/User.java
@@ -95,6 +95,17 @@ public class User {
         return this.statusType == StatusType.BANNED;
     }
 
+    public boolean isWithdrawn() {
+        return this.statusType == StatusType.WITHDRAWN;
+    }
+
+    public void withdrawAccount() {
+        this.statusType = StatusType.WITHDRAWN;
+        this.refreshToken = null;
+        this.nickname = "탈퇴한 사용자";
+        this.profileUrl = null;
+    }
+
     public void updateRole(RoleType roleType) {
         if (roleType != null) this.roleType = roleType;
     }


### PR DESCRIPTION
### 계정관리 기능 구현
- 계정관리 컨트롤러: 기본정보/개인정보/맞춤정보 수정 및 계정탈퇴 API
- 계정 정보 도메인: 전화번호, 출생년도, 성별, 선호장르 관리 엔티티
- 계정관리 서비스: 프로필 이미지 S3 업로드 및 계정 정보 CRUD 로직
- 계정 정보 리포지토리: 사용자별 계정 정보 조회 기능

### DTO 클래스 구현
- `AccountManagementResponse`: 사용자 기본/개인/맞춤 정보 통합 응답
- `KakaoAccountInfoResponse`: 소셜 계정 연결 상태 조회
- `BasicInfoUpdateRequest`: 활동명 수정 기능
- `PersonalInfoUpdateRequest`: 전화번호 수정 기능  
- `CustomInfoUpdateRequest`: 직업/출생년도/성별/관심사/선호장르 수정
- `AccountWithdrawalRequest`: 탈퇴 확인 문구 검증

## TODO 항목
- User 엔티티에 withdrawAccount 메서드 추가 필요
- 카카오 연동 해제 API 호출 필요 (카카오 개발자 콘솔에서 설정)