### PR TITLE
fix/#70: 전일 조회수 비교 및 선형차트 조회수 로직 오류 수정

### DIFF
--- a/src/main/java/com/example/nexus/app/dashboard/domain/scheduler/RedisViewCountScheduler.java
+++ b/src/main/java/com/example/nexus/app/dashboard/domain/scheduler/RedisViewCountScheduler.java
@@ -19,91 +19,60 @@ import java.util.stream.Collectors;
 @Slf4j
 public class RedisViewCountScheduler {
 
-    private final ViewCountService viewCountService;
     private final StringRedisTemplate stringRedisTemplate;
     private final PostRepository postRepository;
 
     private static final String TODAY_VIEW_PREFIX = "view:today:";
     private static final String DAILY_VIEW_PREFIX = "view:daily:";
 
-    // 일별: Redis 키 정리만
+    // 매일 자정: 누적 조회수를 DB와 Redis daily에 저장
     @Scheduled(cron = "0 0 0 * * *")
     @Transactional
-    public void consolidateDailyViewCounts() {
+    public void saveDailyCumulativeViewCounts() {
         LocalDate yesterday = LocalDate.now().minusDays(1);
         String yesterdayStr = yesterday.toString();
 
         try {
-            Set<String> todayViewKeys = stringRedisTemplate.keys(TODAY_VIEW_PREFIX + "*:" + yesterdayStr);
+            // 어제 today 키들 조회
+            Set<String> yesterdayTodayKeys = stringRedisTemplate.keys(TODAY_VIEW_PREFIX + "*:" + yesterdayStr);
 
-            for (String todayKey : todayViewKeys) {
+            if (yesterdayTodayKeys == null || yesterdayTodayKeys.isEmpty()) {
+                log.info("어제 조회수 데이터가 없습니다: {}", yesterdayStr);
+                return;
+            }
+
+            for (String todayKey : yesterdayTodayKeys) {
                 String[] parts = todayKey.split(":");
-                Long postId = Long.parseLong(parts[2]);
+                if (parts.length >= 3) {
+                    Long postId = Long.parseLong(parts[2]);
 
-                String viewCountStr = stringRedisTemplate.opsForValue().get(todayKey);
-                Long viewCount = viewCountStr != null ? Long.parseLong(viewCountStr) : 0L;
+                    // 어제 증가분 조회
+                    String incrementStr = stringRedisTemplate.opsForValue().get(todayKey);
+                    Long yesterdayIncrement = incrementStr != null ? Long.parseLong(incrementStr) : 0L;
 
-                if (viewCount > 0) {
-                    String dailyKey = DAILY_VIEW_PREFIX + postId + ":" + yesterdayStr;
-                    stringRedisTemplate.opsForValue().set(dailyKey, viewCount.toString());
-                    stringRedisTemplate.expire(dailyKey, Duration.ofDays(30));
-                }
+                    if (yesterdayIncrement > 0) {
+                        // DB 업데이트: 기존 누적 조회수 + 어제 증가분
+                        postRepository.findById(postId).ifPresent(post -> {
+                            Long newCumulativeCount = post.getViewCount().longValue() + yesterdayIncrement;
+                            post.updateViewCount(newCumulativeCount.intValue());
+                            postRepository.save(post);
 
-                stringRedisTemplate.delete(todayKey);
-            }
+                            // Redis daily에 어제의 누적 조회수 저장
+                            String dailyKey = DAILY_VIEW_PREFIX + postId + ":" + yesterdayStr;
+                            stringRedisTemplate.opsForValue().set(dailyKey, newCumulativeCount.toString());
+                            stringRedisTemplate.expire(dailyKey, Duration.ofDays(7));
 
-        } catch (Exception e) {
-            log.error("Redis 키 정리 중 오류 발생", e);
-        }
-    }
+                            log.info("누적 조회수 저장: postId={}, date={}, cumulative={}", postId, yesterdayStr, newCumulativeCount);
+                        });
+                    }
 
-    // 주간: DB 동기화
-    @Scheduled(cron = "0 0 1 * * 1")
-    @Transactional
-    public void weeklyDatabaseSync() {
-        LocalDate lastSunday = LocalDate.now().minusDays(7);
-
-        try {
-            Set<String> allPosts = getAllPostIdsFromRedis();
-
-            for (String postIdStr : allPosts) {
-                Long postId = Long.parseLong(postIdStr);
-                Long weeklyTotal = calculateWeeklyTotal(postId, lastSunday);
-
-                if (weeklyTotal > 0) {
-                    updateDatabaseViewCount(postId, weeklyTotal);
+                    // 어제 today 키 삭제
+                    stringRedisTemplate.delete(todayKey);
                 }
             }
 
         } catch (Exception e) {
-            log.error("주간 DB 동기화 중 오류 발생", e);
+            log.error("일별 누적 조회수 저장 중 오류 발생", e);
         }
-    }
-
-    private Long calculateWeeklyTotal(Long postId, LocalDate endDate) {
-        Long weeklyTotal = 0L;
-        for (int i = 0; i < 7; i++) {
-            LocalDate date = endDate.minusDays(i);
-            String dailyKey = DAILY_VIEW_PREFIX + postId + ":" + date.toString();
-            String value = stringRedisTemplate.opsForValue().get(dailyKey);
-            weeklyTotal += (value != null ? Long.parseLong(value) : 0L);
-        }
-        return weeklyTotal;
-    }
-
-    private Set<String> getAllPostIdsFromRedis() {
-        // daily_view 키에서 postId 추출
-        Set<String> dailyKeys = stringRedisTemplate.keys(DAILY_VIEW_PREFIX + "*");
-        return dailyKeys.stream()
-                .map(key -> key.split(":")[2]) // view:daily:123:2024-08-14 → 123
-                .collect(Collectors.toSet());
-    }
-
-    private void updateDatabaseViewCount(Long postId, Long weeklyIncrement) {
-        postRepository.findById(postId).ifPresent(post -> {
-            Integer currentDbCount = post.getViewCount();
-            int newDbCount = currentDbCount + weeklyIncrement.intValue();
-            post.updateViewCount(newDbCount);
-        });
     }
 }

--- a/src/main/java/com/example/nexus/app/post/service/ViewCountService.java
+++ b/src/main/java/com/example/nexus/app/post/service/ViewCountService.java
@@ -22,7 +22,7 @@ public class ViewCountService {
     private static final String TODAY_VIEW_PREFIX = "view:today:";
     private static final String DAILY_VIEW_PREFIX = "view:daily:";
 
-    // 실시간 조회수 증가
+    // 실시간 조회수 증가 (오늘 증가분만)
     public void incrementViewCount(Long postId) {
         try {
             String today = LocalDate.now().toString();
@@ -30,25 +30,40 @@ public class ViewCountService {
 
             stringRedisTemplate.opsForValue().increment(todayKey, 1);
             stringRedisTemplate.expire(todayKey, Duration.ofHours(25));
+
+            log.debug("조회수 증가: postId={}, key={}", postId, todayKey);
         } catch (Exception e) {
             log.error("Redis 조회수 증가 실패: postId={}", postId, e);
         }
     }
 
-    // 오늘 조회수 가져오기
-    public Long getTodayViewCount(Long postId) {
+    // 오늘 증가분 조회
+    public Long getTodayIncrement(Long postId) {
         try {
             String today = LocalDate.now().toString();
             String todayKey = TODAY_VIEW_PREFIX + postId + ":" + today;
             String value = stringRedisTemplate.opsForValue().get(todayKey);
             return value != null ? Long.parseLong(value) : 0L;
         } catch (Exception e) {
-            log.error("오늘 조회수 조회 실패: postId={}", postId, e);
+            log.error("오늘 증가분 조회 실패: postId={}", postId, e);
             return 0L;
         }
     }
 
-    // 어제 조회수 가져오기
+    // 전체 누적 조회수 (DB 기준점 + 오늘 증가분)
+    public Long getTotalViewCount(Long postId) {
+        // DB에 저장된 누적 조회수 (어제까지의 누적)
+        Long dbCumulativeCount = postRepository.findById(postId)
+                .map(post -> post.getViewCount().longValue())
+                .orElse(0L);
+
+        // 오늘 증가분
+        Long todayIncrement = getTodayIncrement(postId);
+
+        return dbCumulativeCount + todayIncrement;
+    }
+
+    // 어제 누적 조회수
     public Long getYesterdayViewCount(Long postId) {
         try {
             LocalDate yesterday = LocalDate.now().minusDays(1);
@@ -56,14 +71,13 @@ public class ViewCountService {
             String value = stringRedisTemplate.opsForValue().get(dailyKey);
 
             if (value != null) {
-                // Redis에 어제 데이터가 있으면 그대로 사용
                 return Long.parseLong(value);
             }
 
-            // Redis에 어제 데이터가 없으면 (총 조회수 - 오늘 조회수)로 계산
-            Long totalCount = getTotalViewCount(postId);
-            Long todayCount = getTodayViewCount(postId);
-            return Math.max(0, totalCount - todayCount);
+            // Redis에 어제 데이터가 없으면 DB 값 사용 (현재 DB 값은 어제까지의 누적)
+            return postRepository.findById(postId)
+                    .map(post -> post.getViewCount().longValue())
+                    .orElse(0L);
 
         } catch (Exception e) {
             log.error("어제 조회수 조회 실패: postId={}", postId, e);
@@ -71,56 +85,27 @@ public class ViewCountService {
         }
     }
 
-    // 전체 조회수
-    public Long getTotalViewCount(Long postId) {
-        // DB 누적 조회수 (배치로 업데이트된 기준점)
-        Long dbViewCount = postRepository.findById(postId)
-                .map(post -> post.getViewCount().longValue())
-                .orElse(0L);
-
-        // 오늘 Redis 증가 값
-        Long todayIncrement = getTodayViewCount(postId);
-
-        return dbViewCount + todayIncrement;
-    }
-
-    // 특정 날짜 조회수 가져오기
-    public Long getDailyViewCount(Long postId, LocalDate date) {
-        try {
-            String dailyKey = DAILY_VIEW_PREFIX + postId + ":" + date.toString();
-            String value = stringRedisTemplate.opsForValue().get(dailyKey);
-            return value != null ? Long.parseLong(value) : 0L;
-
-        } catch (Exception e) {
-            log.error("일별 조회수 조회 실패: postId={}, date={}", postId, date, e);
-            return 0L;
-        }
-    }
-
+    // 일주일간 누적 조회수 (차트용)
     public List<Long> getWeeklyViewCounts(Long postId) {
         List<Long> weeklyViews = new ArrayList<>();
         LocalDate today = LocalDate.now();
-        Long totalDbViewCount = postRepository.findById(postId)
-                .map(post -> post.getViewCount().longValue())
-                .orElse(0L);
 
-        // 7일간 데이터 수집 (오늘부터 6일 전까지)
+        // 7일간 데이터 수집 (6일 전부터 오늘까지)
         for (int i = 6; i >= 0; i--) {
             LocalDate targetDate = today.minusDays(i);
-            Long viewCount;
+            Long cumulativeCount;
 
             if (i == 0) {
-                viewCount = getTodayViewCount(postId);
+                // 오늘: 실시간 누적 조회수
+                cumulativeCount = getTotalViewCount(postId);
             } else {
-                // 과거: 정산된 조회수, 없으면 DB 누적 조회수 사용
-                viewCount = getDailyViewCount(postId, targetDate);
-                if (viewCount == 0L && totalDbViewCount > 0L) {
-                    // Redis에 일별 데이터가 없고 DB에 누적 조회수가 있으면 DB 값 사용
-                    viewCount = totalDbViewCount;
-                }
+                // 과거: Redis에서 해당 날짜의 누적 조회수 조회
+                String dailyKey = DAILY_VIEW_PREFIX + postId + ":" + targetDate.toString();
+                String value = stringRedisTemplate.opsForValue().get(dailyKey);
+                cumulativeCount = value != null ? Long.parseLong(value) : 0L;
             }
 
-            weeklyViews.add(viewCount);
+            weeklyViews.add(cumulativeCount);
         }
 
         return weeklyViews;


### PR DESCRIPTION
# 수정 내용
- 대시보드 통계카드에서 전일 조회수랑 비교하는 로직 오류 해결
- 대시보드 선형차트 일주일 조회수 통계 0으로 표시되는 문제 해결