### PR TITLE
fix/#70: 게시글 조회수 로직 수정

### DIFF
--- a/src/main/java/com/example/nexus/app/post/domain/Post.java
+++ b/src/main/java/com/example/nexus/app/post/domain/Post.java
@@ -235,7 +235,7 @@ public class Post {
         this.qnaMethod = qnaMethod;
     }
 
-    public void updateViewCount(int newDbCount) {
-        this.viewCount = newDbCount;
+    public void incrementViewCount() {
+        viewCount++;
     }
 }

--- a/src/main/java/com/example/nexus/app/post/repository/PostRepository.java
+++ b/src/main/java/com/example/nexus/app/post/repository/PostRepository.java
@@ -54,4 +54,6 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     long countByCreatedBy(Long userId);
 
     Optional<Post> findFirstByCreatedByAndStatusOrderByCreatedAtDesc(Long userId, PostStatus status);
+
+    List<Post> findByStatus(PostStatus postStatus);
 }

--- a/src/main/java/com/example/nexus/app/post/service/ViewCountService.java
+++ b/src/main/java/com/example/nexus/app/post/service/ViewCountService.java
@@ -1,12 +1,13 @@
 package com.example.nexus.app.post.service;
 
+import com.example.nexus.app.post.domain.Post;
 import com.example.nexus.app.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,78 +15,45 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@Transactional(readOnly = true)
 public class ViewCountService {
 
     private final StringRedisTemplate stringRedisTemplate;
     private final PostRepository postRepository;
 
-    private static final String TODAY_VIEW_PREFIX = "view:today:";
     private static final String DAILY_VIEW_PREFIX = "view:daily:";
 
-    // 실시간 조회수 증가 (오늘 증가분만)
+    // 실시간 조회수 증가 - DB 직접 업데이트
+    @Transactional
     public void incrementViewCount(Long postId) {
         try {
-            String today = LocalDate.now().toString();
-            String todayKey = TODAY_VIEW_PREFIX + postId + ":" + today;
-
-            stringRedisTemplate.opsForValue().increment(todayKey, 1);
-            stringRedisTemplate.expire(todayKey, Duration.ofHours(25));
-
-            log.debug("조회수 증가: postId={}, key={}", postId, todayKey);
+            postRepository.findById(postId).ifPresent(Post::incrementViewCount);
         } catch (Exception e) {
-            log.error("Redis 조회수 증가 실패: postId={}", postId, e);
+            log.error("DB 조회수 증가 실패: postId={}", postId, e);
         }
     }
 
-    // 오늘 증가분 조회
-    public Long getTodayIncrement(Long postId) {
-        try {
-            String today = LocalDate.now().toString();
-            String todayKey = TODAY_VIEW_PREFIX + postId + ":" + today;
-            String value = stringRedisTemplate.opsForValue().get(todayKey);
-            return value != null ? Long.parseLong(value) : 0L;
-        } catch (Exception e) {
-            log.error("오늘 증가분 조회 실패: postId={}", postId, e);
-            return 0L;
-        }
-    }
-
-    // 전체 누적 조회수 (DB 기준점 + 오늘 증가분)
+    // 현재 조회수 - DB에서 직접 조회
     public Long getTotalViewCount(Long postId) {
-        // DB에 저장된 누적 조회수 (어제까지의 누적)
-        Long dbCumulativeCount = postRepository.findById(postId)
+        return postRepository.findById(postId)
                 .map(post -> post.getViewCount().longValue())
                 .orElse(0L);
-
-        // 오늘 증가분
-        Long todayIncrement = getTodayIncrement(postId);
-
-        return dbCumulativeCount + todayIncrement;
     }
 
-    // 어제 누적 조회수
+    // 어제 조회수 - Redis에서 조회
     public Long getYesterdayViewCount(Long postId) {
         try {
             LocalDate yesterday = LocalDate.now().minusDays(1);
             String dailyKey = DAILY_VIEW_PREFIX + postId + ":" + yesterday.toString();
             String value = stringRedisTemplate.opsForValue().get(dailyKey);
-
-            if (value != null) {
-                return Long.parseLong(value);
-            }
-
-            // Redis에 어제 데이터가 없으면 DB 값 사용 (현재 DB 값은 어제까지의 누적)
-            return postRepository.findById(postId)
-                    .map(post -> post.getViewCount().longValue())
-                    .orElse(0L);
-
+            return value != null ? Long.parseLong(value) : 0L;
         } catch (Exception e) {
             log.error("어제 조회수 조회 실패: postId={}", postId, e);
             return 0L;
         }
     }
 
-    // 일주일간 누적 조회수 (차트용)
+    // 일주일간 누적 조회수 (선형 차트용)
     public List<Long> getWeeklyViewCounts(Long postId) {
         List<Long> weeklyViews = new ArrayList<>();
         LocalDate today = LocalDate.now();
@@ -96,7 +64,7 @@ public class ViewCountService {
             Long cumulativeCount;
 
             if (i == 0) {
-                // 오늘: 실시간 누적 조회수
+                // 오늘: DB에서 현재 누적 조회수 조회
                 cumulativeCount = getTotalViewCount(postId);
             } else {
                 // 과거: Redis에서 해당 날짜의 누적 조회수 조회


### PR DESCRIPTION
# 수정 내용
- 게시글 상세 조회시 조회수 증가는 DB에서 직접 처리
- 대시보드 통계카드에서 전일 조회수랑 비교하는 로직 오류 해결
- 대시보드 선형차트 일주일 조회수 통계 0으로 표시되는 문제 해결