### PR TITLE
 fix/#78: 로그아웃시 토큰 블랙리스트 처리

### DIFF
--- a/src/main/java/com/example/nexus/app/global/oauth/controller/AuthController.java
+++ b/src/main/java/com/example/nexus/app/global/oauth/controller/AuthController.java
@@ -107,8 +107,10 @@ public class AuthController {
     @Operation(summary = "로그아웃", description = "현재 사용자를 로그아웃 처리합니다.")
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        authService.logout(userDetails.getUserId());
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader) {
+        String accessToken = authorizationHeader.substring(7);
+        authService.logout(userDetails.getUserId(), accessToken);
         return ResponseEntity.ok(ApiResponse.onSuccess(null));
     }
 

--- a/src/main/java/com/example/nexus/app/global/oauth/service/AuthService.java
+++ b/src/main/java/com/example/nexus/app/global/oauth/service/AuthService.java
@@ -151,7 +151,11 @@ public class AuthService {
     }
 
     @Transactional
-    public void logout(Long userId) {
+    public void logout(Long userId, String accessToken) {
+        // 액세스 토큰을 블랙리스트에 추가
+        if (accessToken != null && !accessToken.isEmpty()) {
+            tokenBlacklistService.blacklistToken(accessToken);
+        }
         accountManagementService.logout(userId);
     }
 


### PR DESCRIPTION
* `AuthController` : 로그아웃 엔드포인트에서 Authorization 헤더를 파싱하여 accessToken을 추출

*  `JwtAuthenticationProcessingFilter` : 블랙리스트에 등록된 토큰에 대해 `401 Unauthorized` 응답 반환

* 보안 강화: 로그아웃된 토큰으로 API 접근 차단