### PR TITLE
fix/#98: 조회수 동시성 문제 해결 및 null 안전성 개선

### DIFF
--- a/src/main/java/com/example/nexus/app/message/repository/MessageRepository.java
+++ b/src/main/java/com/example/nexus/app/message/repository/MessageRepository.java
@@ -42,6 +42,10 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
             "AND m.isDeleted = false")
     long countUnreadMessagesByRoom(@Param("roomId") Long roomId, @Param("userId") Long userId);
 
+    @Query("SELECT m FROM Message m " +
+            "JOIN FETCH m.sender " +
+            "WHERE m.room.post.id = :postId " +
+            "ORDER BY m.createdAt DESC")
     Page<Message> findByRoomPostId(Long postId, Pageable pageable);
 
     @Query("SELECT SUM(unread.count) FROM (" +

--- a/src/main/java/com/example/nexus/app/post/controller/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/example/nexus/app/post/controller/dto/response/PostDetailResponse.java
@@ -106,7 +106,7 @@ public record PostDetailResponse(
                 post.getStatus(),
                 post.getQnaMethod(),
                 post.getLikeCount(),
-                currentViewCount.intValue(),
+                currentViewCount != null ? currentViewCount.intValue() : 0,
                 post.getCurrentParticipants(),
                 post.getSchedule() != null ? PostScheduleResponse.from(post.getSchedule()) : null,
                 post.getRequirement() != null ? PostRequirementResponse.from(post.getRequirement()) : null,

--- a/src/main/java/com/example/nexus/app/post/repository/ParticipantRewardRepository.java
+++ b/src/main/java/com/example/nexus/app/post/repository/ParticipantRewardRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ParticipantRewardRepository extends JpaRepository<ParticipantReward, Long> {
@@ -15,4 +16,8 @@ public interface ParticipantRewardRepository extends JpaRepository<ParticipantRe
             "FROM ParticipantReward pr " +
             "WHERE pr.participation.post.id =:postId AND pr.rewardStatus = :status")
     Long countByPostIdAndRewardStatus(@Param("postId") Long postId, @Param("status") RewardStatus status);
+
+    @Query("SELECT pr FROM ParticipantReward pr " +
+            "WHERE pr.participation.id IN :participationIds")
+    List<ParticipantReward> findByParticipationIds(@Param("participationIds") List<Long> participationIds);
 }

--- a/src/main/java/com/example/nexus/app/post/repository/ParticipationRepository.java
+++ b/src/main/java/com/example/nexus/app/post/repository/ParticipationRepository.java
@@ -2,7 +2,6 @@ package com.example.nexus.app.post.repository;
 
 import com.example.nexus.app.post.domain.Participation;
 import com.example.nexus.app.post.domain.ParticipationStatus;
-import com.example.nexus.app.post.domain.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public interface ParticipationRepository extends JpaRepository<Participation, Long>, ParticipationRepositoryCustom {
@@ -21,15 +21,26 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 
     // 사용자의 모든 참가 신청 내역
     @Query("SELECT p FROM Participation p " +
-            "JOIN FETCH p.post " +
+            "JOIN FETCH p.post po " +
+            "JOIN FETCH p.user " +
+            "LEFT JOIN FETCH po.schedule " +
+            "LEFT JOIN FETCH po.requirement " +
+            "LEFT JOIN FETCH po.reward " +
+            "LEFT JOIN FETCH po.feedback " +
+            "LEFT JOIN FETCH po.postContent " +
             "WHERE p.user.id = :userId " +
             "ORDER BY p.appliedAt DESC")
     Page<Participation> findByUserIdWithPost(@Param("userId") Long userId, Pageable pageable);
 
     // 사용자의 특정 상태 참가 신청 내역
     @Query("SELECT p FROM Participation p " +
-            "JOIN FETCH p.post " +
+            "JOIN FETCH p.post po " +
             "JOIN FETCH p.user " +
+            "LEFT JOIN FETCH po.schedule " +
+            "LEFT JOIN FETCH po.requirement " +
+            "LEFT JOIN FETCH po.reward " +
+            "LEFT JOIN FETCH po.feedback " +
+            "LEFT JOIN FETCH po.postContent " +
             "WHERE p.user.id = :userId AND p.status = :status " +
             "ORDER BY p.appliedAt DESC")
     Page<Participation> findByUserIdAndStatusWithPost(@Param("userId") Long userId, @Param("status") ParticipationStatus status,
@@ -38,6 +49,12 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
     // 게시글의 참가 신청자 목록 조회
     @Query("SELECT p FROM Participation p " +
             "JOIN FETCH p.user " +
+            "JOIN FETCH p.post po " +
+            "LEFT JOIN FETCH po.schedule " +
+            "LEFT JOIN FETCH po.requirement " +
+            "LEFT JOIN FETCH po.reward " +
+            "LEFT JOIN FETCH po.feedback " +
+            "LEFT JOIN FETCH po.postContent " +
             "WHERE p.post.id = :postId " +
             "ORDER BY p.appliedAt ASC")
     Page<Participation> findByPostIdWithUser(@Param("postId") Long postId, Pageable pageable);
@@ -45,6 +62,12 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
     // 게시글의 특정 상태 참가 신청자 목록 조회
     @Query("SELECT p FROM Participation p " +
             "JOIN FETCH p.user " +
+            "JOIN FETCH p.post po " +
+            "LEFT JOIN FETCH po.schedule " +
+            "LEFT JOIN FETCH po.requirement " +
+            "LEFT JOIN FETCH po.reward " +
+            "LEFT JOIN FETCH po.feedback " +
+            "LEFT JOIN FETCH po.postContent " +
             "WHERE p.post.id = :postId AND p.status = :status " +
             "ORDER BY p.appliedAt ASC")
     Page<Participation> findByPostIdAndStatusWithUser(@Param("postId") Long postId, @Param("status") ParticipationStatus status,
@@ -56,8 +79,8 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
             "AND p.status = 'APPROVED'")
     Set<Long> findApprovedPostIdsByUserIdAndPostIds(@Param("userId") Long userId, @Param("postIds") List<Long> postIds);
 
-    @Query("SELECT p " +
-            "FROM Participation p " +
+    @Query("SELECT p " + "FROM Participation p " +
+            "JOIN FETCH p.user " +
             "WHERE p.post.id = :postId AND p.status = :status " +
             "ORDER BY p.appliedAt DESC")
     Page<Participation> findByPostIdAndStatus(@Param("postId") Long postId, @Param("status") ParticipationStatus status, Pageable pageable);
@@ -67,10 +90,34 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
     Long countByPostIdAndStatusAndAppliedAtBefore(Long postId, ParticipationStatus status, LocalDateTime dateTime);
     Long countByPostIdAndStatusAndApprovedAtBefore(Long postId, ParticipationStatus status, LocalDateTime dateTime);
 
+    @Query("SELECT p FROM Participation p " +
+            "JOIN FETCH p.user " +
+            "WHERE p.post.id = :postId")
     Page<Participation> findByPostId(Long postId, Pageable pageable);
 
     @Query("SELECT p FROM Participation p JOIN FETCH p.post WHERE p.user.id = :userId AND p.status = :status")
     List<Participation> findByUserIdAndStatusWithPost(@Param("userId") Long userId, @Param("status") ParticipationStatus status);
 
     long countByUserIdAndStatus(Long userId, ParticipationStatus status);
+
+    @Query("SELECT p FROM Participation p " +
+            "JOIN FETCH p.post po " +
+            "LEFT JOIN FETCH po.reward " +
+            "WHERE p.id = :participationId")
+    Optional<Participation> findByIdWithPostAndReward(@Param("participationId") Long participationId);
+
+    @Query("SELECT DATE(p.appliedAt) as date, COUNT(p) as count " +
+            "FROM Participation p " +
+            "WHERE p.post.id = :postId AND p.status = :status " +
+            "AND p.appliedAt >= :startDate AND p.appliedAt < :endDate " +
+            "GROUP BY DATE(p.appliedAt) " +
+            "ORDER BY DATE(p.appliedAt)")
+    List<Object[]> countByPostIdAndStatusGroupByDate(@Param("postId") Long postId, @Param("status") ParticipationStatus status, @Param("startDate") LocalDateTime startDate,
+                                                     @Param("endDate") LocalDateTime endDate);
+
+    @Query("SELECT p FROM Participation p " +
+            "JOIN FETCH p.user " +
+            "JOIN FETCH p.post " +
+            "WHERE p.id = :participationId")
+    Optional<Participation> findByIdWithUserAndPost(@Param("participationId") Long participationId);
 }

--- a/src/main/java/com/example/nexus/app/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/example/nexus/app/post/repository/PostLikeRepository.java
@@ -45,4 +45,12 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     // 마이페이지 관심 목록 - 마감 임박 테스트 조회용 메서드
     @Query("SELECT p FROM PostLike pl JOIN pl.post p WHERE pl.user.id = :userId AND p.status = 'ACTIVE' AND p.schedule.recruitmentDeadline >= CURRENT_DATE() ORDER BY p.schedule.recruitmentDeadline ASC")
     List<Post> findLikedPostsWithNearingDeadline(@Param("userId") Long userId);
+
+    @Query("SELECT DATE(pl.createdAt) as date, COUNT(pl) as count " +
+            "FROM PostLike pl " +
+            "WHERE pl.post.id = :postId " +
+            "AND pl.createdAt >= :startDate AND pl.createdAt < :endDate " +
+            "GROUP BY DATE(pl.createdAt) " +
+            "ORDER BY DATE(pl.createdAt)")
+    List<Object[]> countByPostIdGroupByDate(@Param("postId") Long postId, @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 }

--- a/src/main/java/com/example/nexus/app/post/repository/PostRepository.java
+++ b/src/main/java/com/example/nexus/app/post/repository/PostRepository.java
@@ -20,21 +20,6 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
             "LEFT JOIN FETCH p.reward " +
             "LEFT JOIN FETCH p.feedback " +
             "LEFT JOIN FETCH p.postContent " +
-            "WHERE p.status = :status " +
-            "ORDER BY p.createdAt DESC")
-    Page<Post> findByStatusOrderByCreatedAtDesc(@Param("status") PostStatus status, Pageable pageable);
-
-    List<Post> findByCreatedByAndStatus(Long createdBy, PostStatus status);
-
-    List<Post> findByCreatedByAndStatusOrderByCreatedAtDesc(Long userId, PostStatus status);
-
-    @Query("SELECT p " +
-            "FROM Post p " +
-            "LEFT JOIN FETCH p.schedule " +
-            "LEFT JOIN FETCH p.requirement " +
-            "LEFT JOIN FETCH p.reward " +
-            "LEFT JOIN FETCH p.feedback " +
-            "LEFT JOIN FETCH p.postContent " +
             "WHERE p.id = :postId")
     Optional<Post> findByIdWithAllDetails(@Param("postId") Long postId);
 
@@ -56,4 +41,13 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     Optional<Post> findFirstByCreatedByAndStatusOrderByCreatedAtDesc(Long userId, PostStatus status);
 
     List<Post> findByStatus(PostStatus postStatus);
+
+    @Query("SELECT p FROM Post p " +
+            "LEFT JOIN FETCH p.schedule " +
+            "LEFT JOIN FETCH p.requirement " +
+            "LEFT JOIN FETCH p.reward " +
+            "LEFT JOIN FETCH p.feedback " +
+            "LEFT JOIN FETCH p.postContent " +
+            "WHERE p.id = :postId")
+    Optional<Post> findByIdWithAllDetailsAndUser(@Param("postId") Long postId);
 }

--- a/src/main/java/com/example/nexus/app/post/service/PostLikeService.java
+++ b/src/main/java/com/example/nexus/app/post/service/PostLikeService.java
@@ -80,10 +80,12 @@ public class PostLikeService {
                 .toList();
 
         Map<Long, PostUserStatusService.PostUserStatus> statusMap = postUserStatusService.getPostUserStatuses(postIds, userId);
+        Map<Long, Long> viewCountMap = viewCountService.getViewCountsForPosts(postIds);
 
         return likes.map(like -> {
-            PostUserStatusService.PostUserStatus status = statusMap.get(like.getPost().getId());
-            Long currentViewCount = viewCountService.getTotalViewCount(like.getPost().getId());
+            Long postId = like.getPost().getId();
+            PostUserStatusService.PostUserStatus status = statusMap.getOrDefault(postId, new PostUserStatusService.PostUserStatus(false, false));
+            Long currentViewCount = viewCountMap.getOrDefault(postId, 0L);
             return PostDetailResponse.from(like.getPost(), status.isLiked(), status.isParticipated(), currentViewCount);
         });
     }

--- a/src/main/java/com/example/nexus/app/post/service/ViewCountService.java
+++ b/src/main/java/com/example/nexus/app/post/service/ViewCountService.java
@@ -11,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -77,5 +79,14 @@ public class ViewCountService {
         }
 
         return weeklyViews;
+    }
+
+    // Redis에서 일괄 조회
+    public Map<Long, Long> getViewCountsForPosts(List<Long> postIds) {
+        return postIds.stream()
+                .collect(Collectors.toMap(
+                        postId -> postId,
+                        this::getTotalViewCount
+                ));
     }
 }

--- a/src/main/java/com/example/nexus/app/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/nexus/app/review/repository/ReviewRepository.java
@@ -23,6 +23,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("SELECT r FROM Review r JOIN FETCH r.createdBy WHERE r.postId = :postId")
     List<Review> findByPostId(@Param("postId") Long postId);
 
+    @Query("SELECT r FROM Review r " +
+            "JOIN FETCH r.createdBy " +
+            "WHERE r.postId = :postId " +
+            "ORDER BY r.createdAt DESC")
     Page<Review> findByPostIdOrderByCreatedAtDesc(Long postId, Pageable pageable);
 
     Long countByPostId(Long postId);


### PR DESCRIPTION
- ViewCountService: Redis 기반 조회수 관리로 동시성 문제 해결
- JOIN FETCH로 N+1 쿼리 문제 해결
- Map 조회 시 getOrDefault로 NPE 방지
- PostDeatilResponse: currentViewCount null 체크 추가
- DashboardService: 날짜 타입 캐스팅 명시화