### PR TITLE
feat/#130: 게시글 생성 시 제작 팀원 수 저장 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ out/
 src/main/resources/application-secret.yml
 src/main/resources/application-local.yml
 /.github/
+
+### QClass ###
+/src/main/generated/
+/src/test/generated/

--- a/src/main/java/com/example/nexus/app/post/controller/PostController.java
+++ b/src/main/java/com/example/nexus/app/post/controller/PostController.java
@@ -12,9 +12,6 @@ import com.example.nexus.app.post.controller.dto.response.PostRightSidebarRespon
 import com.example.nexus.app.post.controller.dto.response.PostSummaryResponse;
 import com.example.nexus.app.post.controller.dto.response.SimilarPostResponse;
 import com.example.nexus.app.post.service.PostService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -27,7 +24,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -90,7 +95,8 @@ public class PostController implements PostControllerDoc {
             HttpServletRequest httpServletRequest,
             HttpServletResponse httpServletResponse,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        boolean shouldIncrementView = cookieService.shouldIncrementViewAndSetCookie(postId, httpServletRequest, httpServletResponse);
+        boolean shouldIncrementView = cookieService.shouldIncrementViewAndSetCookie(postId, httpServletRequest,
+                httpServletResponse);
 
         Long userId = userDetails != null ? userDetails.getUserId() : null;
 
@@ -107,7 +113,8 @@ public class PostController implements PostControllerDoc {
             @RequestParam(required = false) String keyword,
             @RequestParam(defaultValue = "latest") String sortBy,
             @PageableDefault(size = 20) Pageable pageable) {
-        Page<PostSummaryResponse> posts = postService.findPosts(mainCategory, platformCategory, genreCategory, keyword, sortBy, pageable);
+        Page<PostSummaryResponse> posts = postService.findPosts(mainCategory, platformCategory, genreCategory, keyword,
+                sortBy, pageable);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(posts));
     }

--- a/src/main/java/com/example/nexus/app/post/controller/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/example/nexus/app/post/controller/dto/request/PostCreateRequest.java
@@ -7,6 +7,8 @@ import com.example.nexus.app.post.domain.*;
 import com.example.nexus.app.reward.domain.PostReward;
 import com.example.nexus.app.reward.domain.RewardType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -90,15 +92,29 @@ public record PostCreateRequest(
         String storyGuide,
 
         @Schema(description = "미디어 URL (파일 업로드 시 무시됨)", example = "https://example.com/demo-video")
-        String mediaUrl
+        String mediaUrl,
+
+        @Schema(description = "테스트 제작 팀원 수 (제작자 본인 포함)", example = "4")
+        Integer teamMemberCount
 ) {
-    public Post toPostEntity() {
-        return toPostEntity(PostStatus.ACTIVE);
+    public Post toPostEntity(PostStatus status) {
+        return Post.builder()
+                .title(title)
+                .serviceSummary(serviceSummary)
+                .creatorIntroduction(creatorIntroduction)
+                .description(description)
+                .thumbnailUrl(null)
+                .mainCategory(mainCategory)
+                .platformCategory(platformCategory)
+                .genreCategories(genreCategories)
+                .status(status)
+                .qnaMethod(qnaMethod)
+                .teamMemberCount(teamMemberCount)
+                .build();
     }
 
-    public Post toPostEntity(PostStatus status) {
-        return new Post(title, serviceSummary, creatorIntroduction, description,
-                null, mainCategory, platformCategory, genreCategories, status, qnaMethod);
+    public Post toPostEntity() {
+        return toPostEntity(PostStatus.ACTIVE);
     }
 
     public PostSchedule toPostScheduleEntity(Post post) {

--- a/src/main/java/com/example/nexus/app/post/controller/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/example/nexus/app/post/controller/dto/request/PostUpdateRequest.java
@@ -3,15 +3,11 @@ package com.example.nexus.app.post.controller.dto.request;
 import com.example.nexus.app.category.domain.GenreCategory;
 import com.example.nexus.app.category.domain.MainCategory;
 import com.example.nexus.app.category.domain.PlatformCategory;
-import com.example.nexus.app.post.domain.*;
+import com.example.nexus.app.post.domain.Post;
+import com.example.nexus.app.post.domain.PrivacyItem;
 import com.example.nexus.app.reward.domain.PostReward;
 import com.example.nexus.app.reward.domain.RewardType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import java.util.List;
-import java.util.ArrayList;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
@@ -90,32 +86,12 @@ public record PostUpdateRequest(
         String storyGuide,
 
         @Schema(description = "미디어 URL (파일 업로드 시 무시됨)", example = "https://example.com/updated-demo-video")
-        String mediaUrl
+        String mediaUrl,
+
+        @Schema(description = "테스트 제작 팀원 수 (제작자 본인 포함)", example = "4")
+        Integer teamMemberCount
 ) {
-
-    public PostSchedule toPostScheduleEntity(Post post) {
-        return PostSchedule.create(post, startDate, endDate, recruitmentDeadline, durationTime);
-    }
-
-    public PostRequirement toPostRequirementEntity(Post post) {
-        return PostRequirement.create(post, maxParticipants, genderRequirement, ageMin, ageMax, additionalRequirements);
-    }
-
     public PostReward toPostRewardEntity(Post post) {
         return PostReward.create(post, rewardType, rewardDescription);
-    }
-
-    public PostFeedback toPostFeedbackEntity(Post post) {
-        return PostFeedback.create(post, feedbackMethod, feedbackItems, privacyItems);
-    }
-
-    public PostContent toPostContentEntity(Post post) {
-        List<String> mediaUrls = mediaUrl != null ? List.of(mediaUrl) : new ArrayList<>();
-        return PostContent.create(post, participationMethod, storyGuide, mediaUrls);
-    }
-
-    public Post toPostEntity() {
-        return new Post(title, serviceSummary, creatorIntroduction, description,
-                null, mainCategory, platformCategory, genreCategories, qnaMethod);
     }
 }

--- a/src/main/java/com/example/nexus/app/post/domain/Post.java
+++ b/src/main/java/com/example/nexus/app/post/domain/Post.java
@@ -5,6 +5,7 @@ import com.example.nexus.app.category.domain.MainCategory;
 import com.example.nexus.app.category.domain.PlatformCategory;
 import com.example.nexus.app.reward.domain.PostReward;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedBy;
@@ -79,6 +80,9 @@ public class Post {
     @Column(name = "current_participants", nullable = false)
     private Integer currentParticipants = 0;
 
+    @Column(name = "team_member_count")
+    private Integer teamMemberCount;
+
     @OneToOne(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private PostSchedule schedule;
 
@@ -110,9 +114,10 @@ public class Post {
     @Column(name = "updated_by", nullable = false)
     private Long updatedBy;
 
+    @Builder
     public Post(String title, String serviceSummary, String creatorIntroduction, String description,
                 String thumbnailUrl, Set<MainCategory> mainCategory, Set<PlatformCategory> platformCategory,
-                Set<GenreCategory> genreCategories, PostStatus status, String qnaMethod) {
+                Set<GenreCategory> genreCategories, PostStatus status, String qnaMethod, Integer teamMemberCount) {
         this.title = title;
         this.serviceSummary = serviceSummary;
         this.creatorIntroduction = creatorIntroduction;
@@ -120,6 +125,7 @@ public class Post {
         this.thumbnailUrl = thumbnailUrl;
         this.status = status;
         this.qnaMethod = qnaMethod;
+        this.teamMemberCount = teamMemberCount;
 
         if (mainCategory != null) {
             this.mainCategory = new HashSet<>(mainCategory);
@@ -130,13 +136,6 @@ public class Post {
         if (genreCategories != null) {
             this.genreCategories = new HashSet<>(genreCategories);
         }
-    }
-
-    public Post(String title, String serviceSummary, String creatorIntroduction, String description,
-                String thumbnailUrl, Set<MainCategory> mainCategory, Set<PlatformCategory> platformCategory,
-                Set<GenreCategory> genreCategories, String qnaMethod) {
-        this(title, serviceSummary, creatorIntroduction, description, thumbnailUrl, 
-             mainCategory, platformCategory, genreCategories, PostStatus.DRAFT, qnaMethod);
     }
 
     public void updateQnaMethod(String qnaMethod) {
@@ -227,13 +226,15 @@ public class Post {
 
     public void updateBasicInfo(String title, String serviceSummary,
                                 String creatorIntroduction, String description,
-                                String thumbnailUrl, String qnaMethod) {
+                                String thumbnailUrl, String qnaMethod,
+                                Integer teamMemberCount) {
         this.title = title;
         this.serviceSummary = serviceSummary;
         this.creatorIntroduction = creatorIntroduction;
         this.description = description;
         this.thumbnailUrl = thumbnailUrl;
         this.qnaMethod = qnaMethod;
+        this.teamMemberCount = teamMemberCount;
     }
 
     public void incrementViewCount() {

--- a/src/main/java/com/example/nexus/app/post/service/PostService.java
+++ b/src/main/java/com/example/nexus/app/post/service/PostService.java
@@ -84,7 +84,7 @@ public class PostService {
 
         String newThumbnailUrl = uploadThumbnailIfPresent(thumbnailFile, post.getThumbnailUrl());
         post.updateBasicInfo(request.title(), request.serviceSummary(), request.creatorIntroduction(),
-                request.description(), newThumbnailUrl, request.qnaMethod());
+                request.description(), newThumbnailUrl, request.qnaMethod(), request.teamMemberCount());
         post.updateMainCategories(request.mainCategory());
         post.updatePlatformCategories(request.platformCategory());
         post.updateGenreCategories(request.genreCategories());
@@ -169,7 +169,7 @@ public class PostService {
 
         String newThumbnailUrl = uploadThumbnailIfPresent(thumbnailFile, post.getThumbnailUrl());
         post.updateBasicInfo(request.title(), request.serviceSummary(), request.creatorIntroduction(),
-                request.description(), newThumbnailUrl, request.qnaMethod());
+                request.description(), newThumbnailUrl, request.qnaMethod(),request.teamMemberCount());
         post.updateMainCategories(request.mainCategory());
         post.updatePlatformCategories(request.platformCategory());
         post.updateGenreCategories(request.genreCategories());
@@ -334,7 +334,7 @@ public class PostService {
 
         if (thumbnailUrl != null) {
             post.updateBasicInfo(post.getTitle(), post.getServiceSummary(),
-                    post.getCreatorIntroduction(), post.getDescription(), thumbnailUrl, post.getQnaMethod());
+                    post.getCreatorIntroduction(), post.getDescription(), thumbnailUrl, post.getQnaMethod(), post.getTeamMemberCount());
         }
         return post;
     }


### PR DESCRIPTION
## 구현 기능

- Post 엔티티에 teamMemberCount 필드 추가
- Builder 패턴 적용으로 Post 엔티티 생성자 개선
- PostCreateRequest, PostUpdateRequest에 팀원 수 입력 필드 추가
- PostService의 updateBasicInfo 로직에 팀원 수 반영
- .gitignore에 QueryDSL 생성 파일 제외 설정 추가