### PR TITLE
fix/#138: 대시보드 quick-actions 참여대기 API 응답 필드 수정

### DIFF
--- a/src/main/java/com/example/nexus/app/dashboard/controller/dto/response/WaitingParticipantResponse.java
+++ b/src/main/java/com/example/nexus/app/dashboard/controller/dto/response/WaitingParticipantResponse.java
@@ -5,8 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record WaitingParticipantResponse(
-        @Schema(description = "참여자 ID")
-        Long participantId,
+        @Schema(description = "참가 신청 ID")
+        Long participationId,
 
         @Schema(description = "참여자 닉네임")
         String nickname,
@@ -18,8 +18,8 @@ public record WaitingParticipantResponse(
         LocalDateTime appliedAt
 
 ) {
-    public static WaitingParticipantResponse of(Long participantId, String nickname, String profileImageUrl,
+    public static WaitingParticipantResponse of(Long participationId, String nickname, String profileImageUrl,
                                                 LocalDateTime appliedAt) {
-        return new WaitingParticipantResponse(participantId, nickname, profileImageUrl, appliedAt);
+        return new WaitingParticipantResponse(participationId, nickname, profileImageUrl, appliedAt);
     }
 }

--- a/src/main/java/com/example/nexus/app/dashboard/service/DashboardService.java
+++ b/src/main/java/com/example/nexus/app/dashboard/service/DashboardService.java
@@ -79,7 +79,7 @@ public class DashboardService {
         Page<Participation> waitingParticipants = participationRepository.findByPostIdAndStatus(postId, ParticipationStatus.PENDING, pageable);
 
         return waitingParticipants.map(participation -> WaitingParticipantResponse.of(
-                participation.getUser().getId(),
+                participation.getId(),
                 participation.getUser().getNickname(),
                 participation.getUser().getProfileUrl(),
                 participation.getAppliedAt()


### PR DESCRIPTION
- participantId를 participationId로 변경
- User ID 대신 Participation ID 반환하도록 수정