### PR TITLE
fix/#140: 참여자 테스트 완료 처리 플로우 개선

### DIFF
--- a/src/main/java/com/example/nexus/app/feedback/service/FeedbackService.java
+++ b/src/main/java/com/example/nexus/app/feedback/service/FeedbackService.java
@@ -110,9 +110,9 @@ public class FeedbackService {
             throw new GeneralException(ErrorStatus.FEEDBACK_ALREADY_EXISTS);
         }
 
-        // 승인 상태 체크 (APPROVED 또는 COMPLETED 모두 가능)
-        if (!participation.isApproved() && !participation.isCompleted()) {
-            throw new GeneralException(ErrorStatus.PARTICIPATION_NOT_APPROVED);
+        // 승인 상태 체크 (TEST_COMPLETE)
+        if (!participation.isTestCompleted()) {
+            throw new GeneralException(ErrorStatus.PARTICIPATION_NOT_TEST_COMPLETED);
         }
 
         Feedback feedback = Feedback.builder()
@@ -136,7 +136,6 @@ public class FeedbackService {
                 .build();
 
         Feedback savedFeedback = feedbackRepository.save(feedback);
-        participation.complete();
 
         feedbackDraftRepository.findByParticipationId(participation.getId())
                 .ifPresent(feedbackDraftRepository::delete);

--- a/src/main/java/com/example/nexus/app/global/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/nexus/app/global/code/status/ErrorStatus.java
@@ -36,6 +36,9 @@ public enum ErrorStatus implements BaseErrorCode {
     REVIEW_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "REVIEW40022", "리뷰 내용은 최대 1000자까지 입력 가능합니다."),
     NOT_PARTICIPATED(HttpStatus.BAD_REQUEST, "REVIEW40023", "해당 게시글에 참여하지 않은 사용자입니다."),
     PARTICIPATION_NOT_APPROVED(HttpStatus.BAD_REQUEST, "FEEDBACK40024", "승인된 참여자만 피드백을 제출할 수 있습니다."),
+    PARTICIPATION_NOT_TEST_COMPLETED(HttpStatus.BAD_REQUEST, "FEEDBACK40025", "테스트 완료 상태에서만 피드백을 제출할 수 있습니다."),
+    FEEDBACK_NOT_SUBMITTED(HttpStatus.BAD_REQUEST, "PARTICIPANT40026", "피드백이 제출되지 않았습니다."),
+    PARTICIPATION_ALREADY_TEST_COMPLETED(HttpStatus.BAD_REQUEST, "PARTICIPANT40027", "이미 테스트 완료 처리된 참여입니다."),
 
     // 401 Unauthorized
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH401", "인증이 필요합니다."),

--- a/src/main/java/com/example/nexus/app/participation/controller/ParticipationController.java
+++ b/src/main/java/com/example/nexus/app/participation/controller/ParticipationController.java
@@ -158,4 +158,13 @@ public class ParticipationController implements ParticipationControllerDoc {
                 participationId, userDetails.getUserId());
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
+
+    @Override
+    @PatchMapping("/my/{participationId}/complete")
+    public ResponseEntity<ApiResponse<Void>> completeTestByParticipant(
+            @PathVariable Long participationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        participationService.completeByParticipant(participationId, userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+    }
 }

--- a/src/main/java/com/example/nexus/app/participation/controller/doc/ParticipationControllerDoc.java
+++ b/src/main/java/com/example/nexus/app/participation/controller/doc/ParticipationControllerDoc.java
@@ -175,4 +175,19 @@ public interface ParticipationControllerDoc {
             @PathVariable Long participationId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     );
+
+    @Operation(
+            summary = "참여자 테스트 완료 처리",
+            description = """
+                  참여자 본인이 테스트를 완료 처리합니다.
+                  - APPROVED(진행중) 상태에서만 호출 가능
+                  - TEST_COMPLETED(테스트 완료) 상태로 변경
+                  - 이후 피드백을 제출해야 함
+                  """
+    )
+    ResponseEntity<ApiResponse<Void>> completeTestByParticipant(
+            @Parameter(description = "참가 신청 ID", required = true)
+            @PathVariable Long participationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
 }

--- a/src/main/java/com/example/nexus/app/participation/domain/Participation.java
+++ b/src/main/java/com/example/nexus/app/participation/domain/Participation.java
@@ -152,4 +152,15 @@ public class Participation {
     public boolean isPaid() {
         return this.isPaid;
     }
+
+    public void completeTest() {
+        if (!isApproved()) {
+            throw new GeneralException(ErrorStatus.PARTICIPATION_NOT_APPROVED);
+        }
+        this.status = ParticipationStatus.TEST_COMPLETED;
+    }
+
+    public boolean isTestCompleted() {
+        return this.status == ParticipationStatus.TEST_COMPLETED;
+    }
 }

--- a/src/main/java/com/example/nexus/app/participation/domain/ParticipationStatus.java
+++ b/src/main/java/com/example/nexus/app/participation/domain/ParticipationStatus.java
@@ -14,6 +14,9 @@ public enum ParticipationStatus {
     @Schema(description = "진행중")
     APPROVED("진행중"),
 
+    @Schema(description = "테스트 완료")
+    TEST_COMPLETED("테스트 완료"),
+
     @Schema(description = "지급 대기")
     COMPLETED("지급 대기"),
 

--- a/src/main/java/com/example/nexus/app/participation/repository/ParticipationRepository.java
+++ b/src/main/java/com/example/nexus/app/participation/repository/ParticipationRepository.java
@@ -176,4 +176,6 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
             @Param("postId") Long postId,
             @Param("status") ParticipationStatus status,
             @Param("isPaid") Boolean isPaid);
+
+    Optional<Participation> findByUserIdAndPostId(Long userId, Long postId);
 }

--- a/src/main/java/com/example/nexus/app/post/controller/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/example/nexus/app/post/controller/dto/response/PostDetailResponse.java
@@ -1,6 +1,7 @@
 package com.example.nexus.app.post.controller.dto.response;
 
 import com.example.nexus.app.category.dto.response.CategoryResponse;
+import com.example.nexus.app.participation.domain.ParticipationStatus;
 import com.example.nexus.app.post.domain.Post;
 import com.example.nexus.app.post.domain.PostStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -79,13 +80,18 @@ public record PostDetailResponse(
         Boolean isLiked,
 
         @Schema(description = "사용자 참여 여부")
-        Boolean isParticipated
+        Boolean isParticipated,
+
+        @Schema(description = "사용자 참여 상태 (null: 미신청, PENDING: 승인대기, APPROVED: 진행중,"
+                + " TEST_COMPLETED: 테스트완료, COMPLETED: 지급대기, REJECTED: 거절)")
+        ParticipationStatus participationStatus
 ) {
     public static PostDetailResponse from(Post post, Boolean isLiked, Boolean isParticipated, Long currentViewCount) {
-        return from(post, isLiked, isParticipated, currentViewCount, null);
+        return from(post, isLiked, isParticipated, currentViewCount, null, null);
     }
 
-    public static PostDetailResponse from(Post post, Boolean isLiked, Boolean isParticipated, Long currentViewCount, String creatorProfileUrl) {
+    public static PostDetailResponse from(Post post, Boolean isLiked, Boolean isParticipated, Long currentViewCount,
+                                          String creatorProfileUrl, ParticipationStatus participationStatus) {
         return new PostDetailResponse(
                 post.getId(),
                 post.getTitle(),
@@ -116,7 +122,8 @@ public record PostDetailResponse(
                 post.getCreatedAt(),
                 post.getCreatedBy(),
                 isLiked,
-                isParticipated
+                isParticipated,
+                participationStatus
         );
     }
 }

--- a/src/main/java/com/example/nexus/app/post/service/PostLikeService.java
+++ b/src/main/java/com/example/nexus/app/post/service/PostLikeService.java
@@ -8,6 +8,7 @@ import com.example.nexus.app.post.domain.Post;
 import com.example.nexus.app.post.domain.PostLike;
 import com.example.nexus.app.post.repository.PostLikeRepository;
 import com.example.nexus.app.post.repository.PostRepository;
+import com.example.nexus.app.post.service.dto.PostUserStatus;
 import com.example.nexus.app.user.domain.User;
 import com.example.nexus.app.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -79,14 +80,15 @@ public class PostLikeService {
                 .map(like -> like.getPost().getId())
                 .toList();
 
-        Map<Long, PostUserStatusService.PostUserStatus> statusMap = postUserStatusService.getPostUserStatuses(postIds, userId);
+        Map<Long, PostUserStatus> statusMap = postUserStatusService.getPostUserStatuses(postIds, userId);
         Map<Long, Long> viewCountMap = viewCountService.getViewCountsForPosts(postIds);
 
         return likes.map(like -> {
             Long postId = like.getPost().getId();
-            PostUserStatusService.PostUserStatus status = statusMap.getOrDefault(postId, new PostUserStatusService.PostUserStatus(false, false));
+            PostUserStatus status = statusMap.getOrDefault(postId, PostUserStatus.empty());
             Long currentViewCount = viewCountMap.getOrDefault(postId, 0L);
-            return PostDetailResponse.from(like.getPost(), status.isLiked(), status.isParticipated(), currentViewCount);
+            return PostDetailResponse.from(like.getPost(), status.isLiked(), status.isParticipated(), currentViewCount,
+                    null, status.participationStatus());
         });
     }
 }

--- a/src/main/java/com/example/nexus/app/post/service/PostService.java
+++ b/src/main/java/com/example/nexus/app/post/service/PostService.java
@@ -20,6 +20,7 @@ import com.example.nexus.app.post.controller.dto.response.PostSummaryResponse;
 import com.example.nexus.app.post.controller.dto.response.SimilarPostResponse;
 import com.example.nexus.app.post.domain.*;
 import com.example.nexus.app.post.repository.*;
+import com.example.nexus.app.post.service.dto.PostUserStatus;
 import com.example.nexus.app.reward.domain.PostReward;
 import com.example.nexus.app.reward.domain.RewardType;
 import com.example.nexus.app.reward.repository.PostRewardRepository;
@@ -141,7 +142,7 @@ public class PostService {
             recentViewedPostService.saveRecentView(userId, postId);
         }
 
-        PostUserStatusService.PostUserStatus status = postUserStatusService.getPostUserStatus(postId, userId);
+        PostUserStatus status = postUserStatusService.getPostUserStatus(postId, userId);
         Long currentViewCount = viewCountService.getTotalViewCount(postId);
 
         String creatorProfileUrl = userRepository.findById(post.getCreatedBy())
@@ -149,7 +150,7 @@ public class PostService {
                 .orElse(null);
 
         return PostDetailResponse.from(post, status.isLiked(), status.isParticipated(), currentViewCount,
-                creatorProfileUrl);
+                creatorProfileUrl, status.participationStatus());
     }
 
 

--- a/src/main/java/com/example/nexus/app/post/service/dto/PostUserStatus.java
+++ b/src/main/java/com/example/nexus/app/post/service/dto/PostUserStatus.java
@@ -1,0 +1,21 @@
+package com.example.nexus.app.post.service.dto;
+
+import com.example.nexus.app.participation.domain.ParticipationStatus;
+
+public record PostUserStatus(
+        Boolean isLiked,
+        Boolean isParticipated,
+        ParticipationStatus participationStatus
+) {
+    public static PostUserStatus empty() {
+        return new PostUserStatus(false, false, null);
+    }
+
+    public static PostUserStatus liked() {
+        return new PostUserStatus(true, null, null);
+    }
+
+    public static PostUserStatus participated() {
+        return new PostUserStatus(null, true, null);
+    }
+}


### PR DESCRIPTION
- ParticipationStatus에 TEST_COMPLETED 상태 추가
- 참여자가 테스트 완료 처리 후 피드백 제출하도록 플로우 변경
- 모집자 완료 처리 시 피드백 제출 여부 검증 추가
- PostDetailResponse에 participationStatus 필드 추가
- 게시글 상세 API에서 사용자의 참여 상태 반환