### PR TITLE
fix/#144: 게시글 수정/임시저장 시 필드 nullable 허용 및 null 체크 추가

### DIFF
--- a/src/main/java/com/example/nexus/app/post/domain/Post.java
+++ b/src/main/java/com/example/nexus/app/post/domain/Post.java
@@ -31,16 +31,15 @@ public class Post {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
     private String title;
 
-    @Column(name = "service_summary", nullable = false)
+    @Column(name = "service_summary")
     private String serviceSummary;
 
-    @Column(name = "creator_introduction", nullable = false)
+    @Column(name = "creator_introduction")
     private String creatorIntroduction;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT")
     private String description;
 
     @Column(name = "thumbnail_url")
@@ -65,7 +64,6 @@ public class Post {
     private Set<GenreCategory> genreCategories = new HashSet<>();
     
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private PostStatus status;
 
     @Column(name = "qna_Method")

--- a/src/main/java/com/example/nexus/app/post/domain/PostContent.java
+++ b/src/main/java/com/example/nexus/app/post/domain/PostContent.java
@@ -20,7 +20,7 @@ public class PostContent {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
-    @Column(name = "participation_method", nullable = false)
+    @Column(name = "participation_method")
     private String participationMethod;
 
     @Column(name = "story_guide", columnDefinition = "TEXT")

--- a/src/main/java/com/example/nexus/app/post/domain/PostFeedback.java
+++ b/src/main/java/com/example/nexus/app/post/domain/PostFeedback.java
@@ -23,7 +23,7 @@ public class PostFeedback {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
-    @Column(name = "feedback_method", nullable = false)
+    @Column(name = "feedback_method")
     private String feedbackMethod;
 
     @ElementCollection(fetch = FetchType.EAGER)

--- a/src/main/java/com/example/nexus/app/post/domain/PostSchedule.java
+++ b/src/main/java/com/example/nexus/app/post/domain/PostSchedule.java
@@ -20,16 +20,16 @@ public class PostSchedule {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
-    @Column(name = "start_date", nullable = false)
+    @Column(name = "start_date")
     private LocalDateTime startDate;
 
-    @Column(name = "end_date", nullable = false)
+    @Column(name = "end_date")
     private LocalDateTime endDate;
 
     @Column(name = "recruitment_deadline")
     private LocalDateTime recruitmentDeadline;
 
-    @Column(name = "duration_time", nullable = false)
+    @Column(name = "duration_time")
     private String durationTime;
 
     public static PostSchedule create(Post post, LocalDateTime startDate, LocalDateTime endDate,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,8 +8,8 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 10MB
-      max-request-size: 10MB
+      max-file-size: 50MB
+      max-request-size: 50MB
 
 springdoc:
   api-docs:


### PR DESCRIPTION
- Post, PostContent, PostFeedback, PostSchedule, PostRequirement nullable 제약 완화
- PostService.updateRelatedEntitiesWithImage에 null 체크 로직 추가
- application.yml 파일 크기 제한 10MB -> 50MB 증가
- getValueOrDefault 헬퍼 메서드 추가로 PATCH 요청 시 기존값 유지