### PR TITLE
refactor/#159: PATCH 업데이트를 위한 엔티티 개별 update 및 Builder 패턴 적용

### DIFF
--- a/src/main/java/com/example/nexus/app/post/controller/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/example/nexus/app/post/controller/dto/request/PostCreateRequest.java
@@ -125,24 +125,51 @@ public record PostCreateRequest(
     }
 
     public PostSchedule toPostScheduleEntity(Post post) {
-        return PostSchedule.create(post, startDate, endDate, recruitmentDeadline, durationTime);
+        return PostSchedule.builder()
+                .post(post)
+                .startDate(startDate)
+                .endDate(endDate)
+                .recruitmentDeadline(recruitmentDeadline)
+                .durationTime(durationTime)
+                .build();
     }
 
     public PostRequirement toPostRequirementEntity(Post post) {
-        return PostRequirement.create(post, maxParticipants, genderRequirement,
-                ageMin, ageMax, additionalRequirements);
+        return PostRequirement.builder()
+                .post(post)
+                .maxParticipants(maxParticipants)
+                .genderRequirement(genderRequirement)
+                .ageMin(ageMin)
+                .ageMax(ageMax)
+                .additionalRequirements(additionalRequirements)
+                .build();
     }
 
     public PostReward toPostRewardEntity(Post post) {
-        return PostReward.create(post, rewardType, rewardDescription);
+        return PostReward.builder()
+                .post(post)
+                .rewardType(rewardType)
+                .rewardDescription(rewardDescription)
+                .build();
     }
 
     public PostFeedback toPostFeedbackEntity(Post post) {
-        return PostFeedback.create(post, feedbackMethod, feedbackItems, privacyItems, privacyPurpose);
+        return PostFeedback.builder()
+                .post(post)
+                .feedbackMethod(feedbackMethod)
+                .feedbackItems(feedbackItems)
+                .privacyItems(privacyItems)
+                .privacyPurpose(privacyPurpose)
+                .build();
     }
 
     public PostContent toPostContentEntity(Post post) {
         List<String> mediaUrls = mediaUrl != null ? List.of(mediaUrl) : new ArrayList<>();
-        return PostContent.create(post, participationMethod, storyGuide, mediaUrls);
+        return PostContent.builder()
+                .post(post)
+                .participationMethod(participationMethod)
+                .storyGuide(storyGuide)
+                .mediaUrls(mediaUrls)
+                .build();
     }
 }

--- a/src/main/java/com/example/nexus/app/post/controller/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/example/nexus/app/post/controller/dto/request/PostUpdateRequest.java
@@ -95,6 +95,10 @@ public record PostUpdateRequest(
         Integer teamMemberCount
 ) {
     public PostReward toPostRewardEntity(Post post) {
-        return PostReward.create(post, rewardType, rewardDescription);
+        return PostReward.builder()
+                .post(post)
+                .rewardType(rewardType)
+                .rewardDescription(rewardDescription)
+                .build();
     }
 }

--- a/src/main/java/com/example/nexus/app/post/domain/Post.java
+++ b/src/main/java/com/example/nexus/app/post/domain/Post.java
@@ -136,8 +136,32 @@ public class Post {
         }
     }
 
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateServiceSummary(String serviceSummary) {
+        this.serviceSummary = serviceSummary;
+    }
+
+    public void updateCreatorIntroduction(String creatorIntroduction) {
+        this.creatorIntroduction = creatorIntroduction;
+    }
+
+    public void updateDescription(String description) {
+        this.description = description;
+    }
+
+    public void updateThumbnailUrl(String thumbnailUrl) {
+        this.thumbnailUrl = thumbnailUrl;
+    }
+
     public void updateQnaMethod(String qnaMethod) {
         this.qnaMethod = qnaMethod;
+    }
+
+    public void updateTeamMemberCount(Integer teamMemberCount) {
+        this.teamMemberCount = teamMemberCount;
     }
 
     public void incrementLikeCount() {
@@ -220,19 +244,6 @@ public class Post {
         if (genreCategories != null) {
             this.genreCategories.addAll(genreCategories);
         }
-    }
-
-    public void updateBasicInfo(String title, String serviceSummary,
-                                String creatorIntroduction, String description,
-                                String thumbnailUrl, String qnaMethod,
-                                Integer teamMemberCount) {
-        this.title = title;
-        this.serviceSummary = serviceSummary;
-        this.creatorIntroduction = creatorIntroduction;
-        this.description = description;
-        this.thumbnailUrl = thumbnailUrl;
-        this.qnaMethod = qnaMethod;
-        this.teamMemberCount = teamMemberCount;
     }
 
     public void incrementViewCount() {

--- a/src/main/java/com/example/nexus/app/post/domain/PostContent.java
+++ b/src/main/java/com/example/nexus/app/post/domain/PostContent.java
@@ -1,6 +1,7 @@
 package com.example.nexus.app.post.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.util.List;
@@ -31,19 +32,23 @@ public class PostContent {
     @Column(name = "media_url")
     private List<String> mediaUrls = new ArrayList<>();
 
-    public static PostContent create(Post post, String participationMethod,
-                                     String storyGuide, List<String> mediaUrls) {
-        PostContent content = new PostContent();
-        content.post = post;
-        content.participationMethod = participationMethod;
-        content.storyGuide = storyGuide;
-        content.mediaUrls = mediaUrls != null ? new ArrayList<>(mediaUrls) : new ArrayList<>();
-        return content;
-    }
-
-    public void update(String participationMethod, String storyGuide, List<String> mediaUrls) {
+    @Builder
+    public PostContent(Post post, String participationMethod, String storyGuide, List<String> mediaUrls) {
+        this.post = post;
         this.participationMethod = participationMethod;
         this.storyGuide = storyGuide;
+        this.mediaUrls = mediaUrls != null ? new ArrayList<>(mediaUrls) : new ArrayList<>();
+    }
+
+    public void updateParticipationMethod(String participationMethod) {
+        this.participationMethod = participationMethod;
+    }
+
+    public void updateStoryGuide(String storyGuide) {
+        this.storyGuide = storyGuide;
+    }
+
+    public void updateMediaUrls(List<String> mediaUrls) {
         this.mediaUrls = mediaUrls != null ? new ArrayList<>(mediaUrls) : new ArrayList<>();
     }
 

--- a/src/main/java/com/example/nexus/app/post/domain/PostFeedback.java
+++ b/src/main/java/com/example/nexus/app/post/domain/PostFeedback.java
@@ -1,6 +1,7 @@
 package com.example.nexus.app.post.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -39,31 +40,39 @@ public class PostFeedback {
 
     private String privacyPurpose;
 
-    public static PostFeedback create(Post post, String feedbackMethod,
-                                      List<String> feedbackItems, Set<PrivacyItem> privacyItems, String privacyPurpose) {
-        PostFeedback feedback = new PostFeedback();
-        feedback.post = post;
-        feedback.feedbackMethod = feedbackMethod;
+    @Builder
+    public PostFeedback(Post post, String feedbackMethod, List<String> feedbackItems,
+                       Set<PrivacyItem> privacyItems, String privacyPurpose) {
+        this.post = post;
+        this.feedbackMethod = feedbackMethod;
         if (feedbackItems != null) {
-            feedback.feedbackItems.addAll(feedbackItems);
+            this.feedbackItems.addAll(feedbackItems);
         }
         if (privacyItems != null) {
-            feedback.privacyItems.addAll(privacyItems);
+            this.privacyItems.addAll(privacyItems);
         }
-        feedback.privacyPurpose = privacyPurpose;
-        return feedback;
+        this.privacyPurpose = privacyPurpose;
     }
 
-    public void update(String feedbackMethod, List<String> feedbackItems, Set<PrivacyItem> privacyItems, String privacyPurpose) {
+    public void updateFeedbackMethod(String feedbackMethod) {
         this.feedbackMethod = feedbackMethod;
+    }
+
+    public void updateFeedbackItems(List<String> feedbackItems) {
         this.feedbackItems.clear();
         if (feedbackItems != null) {
             this.feedbackItems.addAll(feedbackItems);
         }
+    }
+
+    public void updatePrivacyItems(Set<PrivacyItem> privacyItems) {
         this.privacyItems.clear();
         if (privacyItems != null) {
             this.privacyItems.addAll(privacyItems);
         }
+    }
+
+    public void updatePrivacyPurpose(String privacyPurpose) {
         this.privacyPurpose = privacyPurpose;
     }
 

--- a/src/main/java/com/example/nexus/app/post/domain/PostLike.java
+++ b/src/main/java/com/example/nexus/app/post/domain/PostLike.java
@@ -38,11 +38,4 @@ public class PostLike {
         this.user = user;
         this.post = post;
     }
-
-    public static PostLike createPostLike(User user, Post post) {
-        return PostLike.builder()
-                .user(user)
-                .post(post)
-                .build();
-    }
 }

--- a/src/main/java/com/example/nexus/app/post/domain/PostRequirement.java
+++ b/src/main/java/com/example/nexus/app/post/domain/PostRequirement.java
@@ -1,6 +1,7 @@
 package com.example.nexus.app.post.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -33,25 +34,34 @@ public class PostRequirement {
     @Column(name = "additional_requirements", columnDefinition = "TEXT")
     private String additionalRequirements;
 
-    public static PostRequirement create(Post post, Integer maxParticipants,
-                                         String genderRequirement, Integer ageMin, Integer ageMax,
-                                         String additionalRequirements) {
-        PostRequirement requirement = new PostRequirement();
-        requirement.post = post;
-        requirement.maxParticipants = maxParticipants;
-        requirement.genderRequirement = genderRequirement;
-        requirement.ageMin = ageMin;
-        requirement.ageMax = ageMax;
-        requirement.additionalRequirements = additionalRequirements;
-        return requirement;
-    }
-
-    public void update(Integer maxParticipants, String genderRequirement, 
-                      Integer ageMin, Integer ageMax, String additionalRequirements) {
+    @Builder
+    public PostRequirement(Post post, Integer maxParticipants, String genderRequirement,
+                          Integer ageMin, Integer ageMax, String additionalRequirements) {
+        this.post = post;
         this.maxParticipants = maxParticipants;
         this.genderRequirement = genderRequirement;
         this.ageMin = ageMin;
         this.ageMax = ageMax;
+        this.additionalRequirements = additionalRequirements;
+    }
+
+    public void updateMaxParticipants(Integer maxParticipants) {
+        this.maxParticipants = maxParticipants;
+    }
+
+    public void updateGenderRequirement(String genderRequirement) {
+        this.genderRequirement = genderRequirement;
+    }
+
+    public void updateAgeMin(Integer ageMin) {
+        this.ageMin = ageMin;
+    }
+
+    public void updateAgeMax(Integer ageMax) {
+        this.ageMax = ageMax;
+    }
+
+    public void updateAdditionalRequirements(String additionalRequirements) {
         this.additionalRequirements = additionalRequirements;
     }
 }

--- a/src/main/java/com/example/nexus/app/post/domain/PostSchedule.java
+++ b/src/main/java/com/example/nexus/app/post/domain/PostSchedule.java
@@ -1,6 +1,7 @@
 package com.example.nexus.app.post.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,22 +33,29 @@ public class PostSchedule {
     @Column(name = "duration_time")
     private String durationTime;
 
-    public static PostSchedule create(Post post, LocalDateTime startDate, LocalDateTime endDate,
-                                      LocalDateTime recruitmentDeadline, String durationTime) {
-        PostSchedule schedule = new PostSchedule();
-        schedule.post = post;
-        schedule.startDate = startDate;
-        schedule.endDate = endDate;
-        schedule.recruitmentDeadline = recruitmentDeadline;
-        schedule.durationTime = durationTime;
-        return schedule;
-    }
-
-    public void update(LocalDateTime startDate, LocalDateTime endDate,
-                      LocalDateTime recruitmentDeadline, String durationTime) {
+    @Builder
+    public PostSchedule(Post post, LocalDateTime startDate, LocalDateTime endDate,
+                        LocalDateTime recruitmentDeadline, String durationTime) {
+        this.post = post;
         this.startDate = startDate;
         this.endDate = endDate;
         this.recruitmentDeadline = recruitmentDeadline;
+        this.durationTime = durationTime;
+    }
+
+    public void updateStartDate(LocalDateTime startDate) {
+        this.startDate = startDate;
+    }
+
+    public void updateEndDate(LocalDateTime endDate) {
+        this.endDate = endDate;
+    }
+
+    public void updateRecruitmentDeadline(LocalDateTime recruitmentDeadline) {
+        this.recruitmentDeadline = recruitmentDeadline;
+    }
+
+    public void updateDurationTime(String durationTime) {
         this.durationTime = durationTime;
     }
 }

--- a/src/main/java/com/example/nexus/app/post/service/PostLikeService.java
+++ b/src/main/java/com/example/nexus/app/post/service/PostLikeService.java
@@ -42,7 +42,10 @@ public class PostLikeService {
             postLikeRepository.deleteByUserIdAndPostId(userId, postId);
             post.decrementLikeCount();
         } else {
-            PostLike postLike = PostLike.createPostLike(user, post);
+            PostLike postLike = PostLike.builder()
+                    .user(user)
+                    .post(post)
+                    .build();
             postLikeRepository.save(postLike);
             post.incrementLikeCount();
         }

--- a/src/main/java/com/example/nexus/app/post/service/PostService.java
+++ b/src/main/java/com/example/nexus/app/post/service/PostService.java
@@ -93,19 +93,38 @@ public class PostService {
         // Draft를 Active로 변경 전에 상태 확인
         boolean wasDraft = post.isDraft();
 
-        String newThumbnailUrl = uploadThumbnailIfPresent(thumbnailFile, post.getThumbnailUrl());
-        String title = getValueOrDefault(request.title(), post.getTitle());
-        String serviceSummary = getValueOrDefault(request.serviceSummary(), post.getServiceSummary());
-        String creatorIntroduction = getValueOrDefault(request.creatorIntroduction(), post.getCreatorIntroduction());
-        String description = getValueOrDefault(request.description(), post.getDescription());
-        String qnaMethod = getValueOrDefault(request.qnaMethod(), post.getQnaMethod());
-        Integer teamMemberCount = getValueOrDefault(request.teamMemberCount(), post.getTeamMemberCount());
+        if (request.title() != null) {
+            post.updateTitle(request.title());
+        }
+        if (request.serviceSummary() != null) {
+            post.updateServiceSummary(request.serviceSummary());
+        }
+        if (request.creatorIntroduction() != null) {
+            post.updateCreatorIntroduction(request.creatorIntroduction());
+        }
+        if (request.description() != null) {
+            post.updateDescription(request.description());
+        }
+        if (request.qnaMethod() != null) {
+            post.updateQnaMethod(request.qnaMethod());
+        }
+        if (request.teamMemberCount() != null) {
+            post.updateTeamMemberCount(request.teamMemberCount());
+        }
+        if (thumbnailFile != null && !thumbnailFile.isEmpty()) {
+            String thumbnailUrl = s3UploadService.uploadFile(thumbnailFile);
+            post.updateThumbnailUrl(thumbnailUrl);
+        }
 
-        post.updateBasicInfo(title, serviceSummary, creatorIntroduction, description,
-                newThumbnailUrl, qnaMethod, teamMemberCount);
-        post.updateMainCategories(request.mainCategory());
-        post.updatePlatformCategories(request.platformCategory());
-        post.updateGenreCategories(request.genreCategories());
+        if (request.mainCategory() != null) {
+            post.updateMainCategories(request.mainCategory());
+        }
+        if (request.platformCategory() != null) {
+            post.updatePlatformCategories(request.platformCategory());
+        }
+        if (request.genreCategories() != null) {
+            post.updateGenreCategories(request.genreCategories());
+        }
 
         updateRelatedEntitiesWithImage(request, post, imageFiles);
 
@@ -193,19 +212,38 @@ public class PostService {
         Post post = getPostWithDetail(postId);
         validateOwnership(post, userDetails.getUserId());
 
-        String newThumbnailUrl = uploadThumbnailIfPresent(thumbnailFile, post.getThumbnailUrl());
-        String title = getValueOrDefault(request.title(), post.getTitle());
-        String serviceSummary = getValueOrDefault(request.serviceSummary(), post.getServiceSummary());
-        String creatorIntroduction = getValueOrDefault(request.creatorIntroduction(), post.getCreatorIntroduction());
-        String description = getValueOrDefault(request.description(), post.getDescription());
-        String qnaMethod = getValueOrDefault(request.qnaMethod(), post.getQnaMethod());
-        Integer teamMemberCount = getValueOrDefault(request.teamMemberCount(), post.getTeamMemberCount());
+        if (request.title() != null) {
+            post.updateTitle(request.title());
+        }
+        if (request.serviceSummary() != null) {
+            post.updateServiceSummary(request.serviceSummary());
+        }
+        if (request.creatorIntroduction() != null) {
+            post.updateCreatorIntroduction(request.creatorIntroduction());
+        }
+        if (request.description() != null) {
+            post.updateDescription(request.description());
+        }
+        if (request.qnaMethod() != null) {
+            post.updateQnaMethod(request.qnaMethod());
+        }
+        if (request.teamMemberCount() != null) {
+            post.updateTeamMemberCount(request.teamMemberCount());
+        }
+        if (thumbnailFile != null && !thumbnailFile.isEmpty()) {
+            String thumbnailUrl = s3UploadService.uploadFile(thumbnailFile);
+            post.updateThumbnailUrl(thumbnailUrl);
+        }
 
-        post.updateBasicInfo(title, serviceSummary, creatorIntroduction, description,
-                newThumbnailUrl, qnaMethod, teamMemberCount);
-        post.updateMainCategories(request.mainCategory());
-        post.updatePlatformCategories(request.platformCategory());
-        post.updateGenreCategories(request.genreCategories());
+        if (request.mainCategory() != null) {
+            post.updateMainCategories(request.mainCategory());
+        }
+        if (request.platformCategory() != null) {
+            post.updatePlatformCategories(request.platformCategory());
+        }
+        if (request.genreCategories() != null) {
+            post.updateGenreCategories(request.genreCategories());
+        }
 
         updateRelatedEntitiesWithImage(request, post, imageFiles);
     }
@@ -220,32 +258,59 @@ public class PostService {
     }
 
     private void createAndSaveRelatedEntitiesWithImage(PostCreateRequest request, Post post, List<MultipartFile> imageFiles) {
-        PostSchedule schedule = request.toPostScheduleEntity(post);
+        PostSchedule schedule = PostSchedule.builder()
+                .post(post)
+                .startDate(request.startDate())
+                .endDate(request.endDate())
+                .recruitmentDeadline(request.recruitmentDeadline())
+                .durationTime(request.durationTime())
+                .build();
         postScheduleRepository.save(schedule);
 
-        PostRequirement requirement = request.toPostRequirementEntity(post);
+        PostRequirement requirement = PostRequirement.builder()
+                .post(post)
+                .maxParticipants(request.maxParticipants())
+                .genderRequirement(request.genderRequirement())
+                .ageMin(request.ageMin())
+                .ageMax(request.ageMax())
+                .additionalRequirements(request.additionalRequirements())
+                .build();
         postRequirementRepository.save(requirement);
 
         if (request.rewardType() != null) {
-            PostReward reward = request.toPostRewardEntity(post);
+            PostReward reward = PostReward.builder()
+                    .post(post)
+                    .rewardType(request.rewardType())
+                    .rewardDescription(request.rewardDescription())
+                    .build();
             postRewardRepository.save(reward);
         }
 
-        PostFeedback feedback = request.toPostFeedbackEntity(post);
+        PostFeedback feedback = PostFeedback.builder()
+                .post(post)
+                .feedbackMethod(request.feedbackMethod())
+                .feedbackItems(request.feedbackItems())
+                .privacyItems(request.privacyItems())
+                .privacyPurpose(request.privacyPurpose())
+                .build();
         postFeedbackRepository.save(feedback);
 
         // 이미지 파일들 업로드 처리
         List<String> uploadedImageUrls = uploadImagesIfPresent(imageFiles);
         List<String> finalMediaUrls = new ArrayList<>();
-        
+
         if (!uploadedImageUrls.isEmpty()) {
             finalMediaUrls = uploadedImageUrls;
         } else if (request.mediaUrl() != null) {
             finalMediaUrls.add(request.mediaUrl());
         }
-        
-        PostContent content = PostContent.create(post, request.participationMethod(), 
-                request.storyGuide(), finalMediaUrls);
+
+        PostContent content = PostContent.builder()
+                .post(post)
+                .participationMethod(request.participationMethod())
+                .storyGuide(request.storyGuide())
+                .mediaUrls(finalMediaUrls)
+                .build();
         postContentRepository.save(content);
     }
 
@@ -258,22 +323,44 @@ public class PostService {
     }
 
     private void updateSchedule(PostUpdateRequest request, PostSchedule schedule) {
-        LocalDateTime startDate = getValueOrDefault(request.startDate(), schedule.getStartDate());
-        LocalDateTime endDate = getValueOrDefault(request.endDate(), schedule.getEndDate());
-        LocalDateTime recruitmentDeadline = getValueOrDefault(request.recruitmentDeadline(), schedule.getRecruitmentDeadline());
-        String durationTime = getValueOrDefault(request.durationTime(), schedule.getDurationTime());
+        if (schedule == null) {
+            return;
+        }
 
-        schedule.update(startDate, endDate, recruitmentDeadline, durationTime);
+        if (request.startDate() != null) {
+            schedule.updateStartDate(request.startDate());
+        }
+        if (request.endDate() != null) {
+            schedule.updateEndDate(request.endDate());
+        }
+        if (request.recruitmentDeadline() != null) {
+            schedule.updateRecruitmentDeadline(request.recruitmentDeadline());
+        }
+        if (request.durationTime() != null) {
+            schedule.updateDurationTime(request.durationTime());
+        }
     }
 
     private void updateRequirement(PostUpdateRequest request, PostRequirement requirement) {
-        Integer maxParticipants = getValueOrDefault(request.maxParticipants(), requirement.getMaxParticipants());
-        String genderRequirement = getValueOrDefault(request.genderRequirement(), requirement.getGenderRequirement());
-        Integer ageMin = getValueOrDefault(request.ageMin(), requirement.getAgeMin());
-        Integer ageMax = getValueOrDefault(request.ageMax(), requirement.getAgeMax());
-        String additionalRequirements = getValueOrDefault(request.additionalRequirements(), requirement.getAdditionalRequirements());
+        if (requirement == null) {
+            return;
+        }
 
-        requirement.update(maxParticipants, genderRequirement, ageMin, ageMax, additionalRequirements);
+        if (request.maxParticipants() != null) {
+            requirement.updateMaxParticipants(request.maxParticipants());
+        }
+        if (request.genderRequirement() != null) {
+            requirement.updateGenderRequirement(request.genderRequirement());
+        }
+        if (request.ageMin() != null) {
+            requirement.updateAgeMin(request.ageMin());
+        }
+        if (request.ageMax() != null) {
+            requirement.updateAgeMax(request.ageMax());
+        }
+        if (request.additionalRequirements() != null) {
+            requirement.updateAdditionalRequirements(request.additionalRequirements());
+        }
     }
 
     private void updateReward(PostUpdateRequest request, Post post) {
@@ -284,7 +371,11 @@ public class PostService {
         }
 
         if (reward == null) {
-            reward = request.toPostRewardEntity(post);
+            reward = PostReward.builder()
+                    .post(post)
+                    .rewardType(request.rewardType())
+                    .rewardDescription(request.rewardDescription())
+                    .build();
             postRewardRepository.save(reward);
             return;
         }
@@ -294,44 +385,53 @@ public class PostService {
             return;
         }
 
-        RewardType rewardType = getValueOrDefault(request.rewardType(), reward.getRewardType());
-        String rewardDescription = getValueOrDefault(request.rewardDescription(), reward.getRewardDescription());
-
-        reward.update(rewardType, rewardDescription);
+        if (request.rewardType() != null) {
+            reward.updateRewardType(request.rewardType());
+        }
+        if (request.rewardDescription() != null) {
+            reward.updateRewardDescription(request.rewardDescription());
+        }
     }
 
     private void updateFeedback(PostUpdateRequest request, PostFeedback feedback) {
-        String feedbackMethod = getValueOrDefault(request.feedbackMethod(), feedback.getFeedbackMethod());
-        List<String> feedbackItems = getValueOrDefault(request.feedbackItems(), feedback.getFeedbackItems());
-        Set<PrivacyItem> privacyItems = getValueOrDefault(request.privacyItems(), feedback.getPrivacyItems());
-        String privacyPurpose = getValueOrDefault(request.privacyPurpose(), feedback.getPrivacyPurpose());
+        if (feedback == null) {
+            return;
+        }
 
-        feedback.update(feedbackMethod, feedbackItems, privacyItems, privacyPurpose);
+        if (request.feedbackMethod() != null) {
+            feedback.updateFeedbackMethod(request.feedbackMethod());
+        }
+        if (request.feedbackItems() != null) {
+            feedback.updateFeedbackItems(request.feedbackItems());
+        }
+        if (request.privacyItems() != null) {
+            feedback.updatePrivacyItems(request.privacyItems());
+        }
+        if (request.privacyPurpose() != null) {
+            feedback.updatePrivacyPurpose(request.privacyPurpose());
+        }
     }
 
     private void updateContent(PostUpdateRequest request, PostContent content, List<MultipartFile> imageFiles) {
+        if (content == null) {
+            return;
+        }
+
+        if (request.participationMethod() != null) {
+            content.updateParticipationMethod(request.participationMethod());
+        }
+        if (request.storyGuide() != null) {
+            content.updateStoryGuide(request.storyGuide());
+        }
+
         List<String> uploadedImageUrls = uploadImagesIfPresent(imageFiles);
-        List<String> finalMediaUrls = determineMediaUrls(uploadedImageUrls, request.mediaUrl(), content.getMediaUrls());
-
-        String participationMethod = getValueOrDefault(request.participationMethod(), content.getParticipationMethod());
-        String storyGuide = getValueOrDefault(request.storyGuide(), content.getStoryGuide());
-
-        content.update(participationMethod, storyGuide, finalMediaUrls);
-    }
-
-    private List<String> determineMediaUrls(List<String> uploadedUrls, String requestUrl, List<String> existingUrls) {
-        if (!uploadedUrls.isEmpty()) {
-            return uploadedUrls;
+        if (!uploadedImageUrls.isEmpty()) {
+            content.updateMediaUrls(uploadedImageUrls);
+        } else if (request.mediaUrl() != null) {
+            content.updateMediaUrls(List.of(request.mediaUrl()));
         }
-        if (requestUrl != null) {
-            return List.of(requestUrl);
-        }
-        return existingUrls;
     }
 
-    private <T> T getValueOrDefault(T newValue, T defaultValue) {
-        return newValue != null ? newValue : defaultValue;
-    }
 
     private void validatePostForPublishing(Post post) {
         if (post.getSchedule() == null) {
@@ -403,14 +503,13 @@ public class PostService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
     }
 
-    private Post createPostWithThumbnailAndImage(PostCreateRequest request, MultipartFile thumbnailFile, 
+    private Post createPostWithThumbnailAndImage(PostCreateRequest request, MultipartFile thumbnailFile,
                                                  List<MultipartFile> imageFiles, PostStatus status) {
         String thumbnailUrl = uploadThumbnailIfPresent(thumbnailFile, null);
         Post post = (status == PostStatus.DRAFT) ? request.toPostEntity(PostStatus.DRAFT) : request.toPostEntity();
 
         if (thumbnailUrl != null) {
-            post.updateBasicInfo(post.getTitle(), post.getServiceSummary(),
-                    post.getCreatorIntroduction(), post.getDescription(), thumbnailUrl, post.getQnaMethod(), post.getTeamMemberCount());
+            post.updateThumbnailUrl(thumbnailUrl);
         }
         return post;
     }

--- a/src/main/java/com/example/nexus/app/reward/domain/PostReward.java
+++ b/src/main/java/com/example/nexus/app/reward/domain/PostReward.java
@@ -2,6 +2,7 @@ package com.example.nexus.app.reward.domain;
 
 import com.example.nexus.app.post.domain.Post;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,16 +27,18 @@ public class PostReward {
     @Column(name = "reward_description", columnDefinition = "TEXT")
     private String rewardDescription;
 
-    public static PostReward create(Post post, RewardType rewardType, String rewardDescription) {
-        PostReward reward = new PostReward();
-        reward.post = post;
-        reward.rewardType = rewardType;
-        reward.rewardDescription = rewardDescription;
-        return reward;
+    @Builder
+    public PostReward(Post post, RewardType rewardType, String rewardDescription) {
+        this.post = post;
+        this.rewardType = rewardType;
+        this.rewardDescription = rewardDescription;
     }
 
-    public void update(RewardType rewardType, String rewardDescription) {
+    public void updateRewardType(RewardType rewardType) {
         this.rewardType = rewardType;
+    }
+
+    public void updateRewardDescription(String rewardDescription) {
         this.rewardDescription = rewardDescription;
     }
 }


### PR DESCRIPTION
- Post 관련 엔티티에 개별 업데이트 메서드 추가하여 JPA 더티 체킹 활용
- 정적 팩토리 메서드를 Builder 패턴으로 통일
- PostService의 업데이트 로직을 null 체크 기반 개별 업데이트로 변경
- 불필요한 헬퍼 메서드(getValueOrDefault, determineMediaUrls) 제거