### PR TITLE
fix/#162: 동시성 이슈 수정

### DIFF
--- a/src/main/java/com/example/nexus/app/mypage/repository/RecentViewedPostRepository.java
+++ b/src/main/java/com/example/nexus/app/mypage/repository/RecentViewedPostRepository.java
@@ -1,7 +1,9 @@
 package com.example.nexus.app.mypage.repository;
 
 import com.example.nexus.app.mypage.domain.RecentViewedPost;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,6 +15,15 @@ import java.util.Optional;
 @Repository
 public interface RecentViewedPostRepository extends JpaRepository<RecentViewedPost, Long> {
     Optional<RecentViewedPost> findByUserIdAndPostId(Long userId, Long postId);
+    
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM RecentViewedPost r WHERE r.user.id = :userId AND r.post.id = :postId")
+    Optional<RecentViewedPost> findByUserIdAndPostIdWithLock(@Param("userId") Long userId, @Param("postId") Long postId);
+    
+    @Modifying
+    @Query("UPDATE RecentViewedPost r SET r.viewedAt = :viewedAt WHERE r.user.id = :userId AND r.post.id = :postId")
+    int updateViewedAt(@Param("userId") Long userId, @Param("postId") Long postId, @Param("viewedAt") java.time.LocalDateTime viewedAt);
+    
     List<RecentViewedPost> findByUserIdOrderByViewedAtDesc(Long userId);
     void deleteByUserIdAndPostId(Long userId, Long postId);
 

--- a/src/main/java/com/example/nexus/app/mypage/service/RecentViewedPostService.java
+++ b/src/main/java/com/example/nexus/app/mypage/service/RecentViewedPostService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,22 +25,30 @@ public class RecentViewedPostService {
     private final PostRepository postRepository;
 
     public void saveRecentView(Long userId, Long postId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        // Pessimistic Lock을 사용하여 동시성 문제 해결
+        Optional<RecentViewedPost> existingRecord =
+                recentViewedPostRepository.findByUserIdAndPostIdWithLock(userId, postId);
 
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+        if (existingRecord.isPresent()) {
+            int updated = recentViewedPostRepository.updateViewedAt(userId, postId, LocalDateTime.now());
+            if (updated == 0) {
+                throw new GeneralException(ErrorStatus.INTERNAL_SERVER_ERROR);
+            }
+        } else {
+            // 기존 레코드가 없으면 새로 생성
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
-        // 기존에 조회 기록이 있다면 삭제 후 새로 저장
-        recentViewedPostRepository.findByUserIdAndPostId(userId, postId)
-                .ifPresent(recentViewedPostRepository::delete);
+            Post post = postRepository.findById(postId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
 
-        RecentViewedPost newRecord = RecentViewedPost.builder()
-                .user(user)
-                .post(post)
-                .viewedAt(LocalDateTime.now())
-                .build();
-        recentViewedPostRepository.save(newRecord);
+            RecentViewedPost newRecord = RecentViewedPost.builder()
+                    .user(user)
+                    .post(post)
+                    .viewedAt(LocalDateTime.now())
+                    .build();
+            recentViewedPostRepository.save(newRecord);
+        }
     }
     
     public void deleteByPostId(Long postId) {


### PR DESCRIPTION
###  Pessimistic Locking 적용
* findByUserIdAndPostIdWithLock 메서드 추가
*@Lock(LockModeType.PESSIMISTIC_WRITE)로 동시 접근 방지

###  UPSERT 패턴 적용
* 기존 레코드가 있으면 updateViewedAt 쿼리로 업데이트, 없으면 새로 생성
* 삭제 후 생성 대신 업데이트로 변경