### PR TITLE
fix/#168: ViewCountService의 N+1 쿼리 문제 해결

### DIFF
--- a/src/main/java/com/example/nexus/app/post/repository/PostRepository.java
+++ b/src/main/java/com/example/nexus/app/post/repository/PostRepository.java
@@ -124,4 +124,10 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     @Modifying
     @Query("UPDATE Post p SET p.likeCount = p.likeCount - 1 WHERE p.id = :postId AND p.likeCount > 0")
     void decrementLikeCount(@Param("postId") Long postId);
+
+    /**
+     * 조회수 배치 조회
+     */
+    @Query("SELECT p.id, p.viewCount FROM Post p WHERE p.id IN :postIds")
+    List<Object[]> findViewCountsByPostsIds(@Param("postIds") List<Long> postsIds);
 }

--- a/src/main/java/com/example/nexus/app/post/service/ViewCountService.java
+++ b/src/main/java/com/example/nexus/app/post/service/ViewCountService.java
@@ -81,12 +81,11 @@ public class ViewCountService {
         return weeklyViews;
     }
 
-    // Redis에서 일괄 조회
     public Map<Long, Long> getViewCountsForPosts(List<Long> postIds) {
-        return postIds.stream()
+        return postRepository.findViewCountsByPostsIds(postIds).stream()
                 .collect(Collectors.toMap(
-                        postId -> postId,
-                        this::getTotalViewCount
+                        row -> (Long) row[0],
+                        row -> ((Number) row[1]).longValue()
                 ));
     }
 }


### PR DESCRIPTION
- PostRepository에 배치 조회 메서드 추가 (findViewCountsByPostsIds)
- ViewCountService.getViewCountsForPosts()를 배치 조회 방식으로 변경